### PR TITLE
Enhanced Table filter status, sorting indicator and css/layout

### DIFF
--- a/enhancedTable/index.ts
+++ b/enhancedTable/index.ts
@@ -16,7 +16,9 @@ class TableBuilder {
             if (attrs.length === 0) {
                 // make sure all attributes are added before creating the table (otherwise table displays without svgs)
                 this.mapApi.layers.attributesAdded.pipe(take(1)).subscribe(attrs => {
-                    this.createTable(attrs);
+                    if (attrs.attributes[0] && attrs.attributes[0]['rvSymbol'] !== undefined && attrs.attributes[0]['rvInteractive'] !== undefined) {
+                        this.createTable(attrs);
+                    }
                 });
             } else {
                 this.createTable({
@@ -29,21 +31,35 @@ class TableBuilder {
 
     createTable(attrBundle: AttrBundle) {
         let cols: Array<any> = [];
+        let firstColPopulated: boolean = false;
 
         Object.keys(attrBundle.attributes[0]).forEach(columnName => {
             if (columnName !== 'rvSymbol' && columnName !== 'rvInteractive') {
-                cols.push({
-                    headerName: this.attributeHeaders[columnName] ? this.attributeHeaders[columnName]['name'] : '',
-                    headerTooltip: this.attributeHeaders[columnName] ? this.attributeHeaders[columnName]['name'] : '',
-                    field: columnName
-                });
-            } else if (columnName === 'rvSymbol') {
+                if (!firstColPopulated) {
+                    firstColPopulated = true;
+                    //the first column will have a default sort indicator
+                    cols.push({
+                        headerName: this.attributeHeaders[columnName] ? this.attributeHeaders[columnName]['name'] : '',
+                        headerTooltip: this.attributeHeaders[columnName] ? this.attributeHeaders[columnName]['name'] : '',
+                        field: columnName,
+                        sort: 'asc'
+                    })
+                }
+                else {
+                    cols.push({
+                        headerName: this.attributeHeaders[columnName] ? this.attributeHeaders[columnName]['name'] : '',
+                        headerTooltip: this.attributeHeaders[columnName] ? this.attributeHeaders[columnName]['name'] : '',
+                        field: columnName
+                    })
+                }
+            }
+            else if (columnName === 'rvSymbol') {
                 cols = [
                     {
                         headerName: '',
                         headerTooltip: '',
                         field: columnName,
-                        cellRenderer: function(cellImg) {
+                        cellRenderer: function (cellImg) {
                             return cellImg.value;
                         },
                         suppressSorting: true,

--- a/enhancedTable/panel-manager.ts
+++ b/enhancedTable/panel-manager.ts
@@ -9,6 +9,7 @@ import './main.scss';
  * This class also contains custom angular controllers to enable searching, printing, exporting, and more from angular material panel controls.
  */
 export class PanelManager {
+
     constructor(mapApi: any) {
         this.mapApi = mapApi;
         this.tableContent = $(`<div rv-focus-exempt></div>`);
@@ -37,8 +38,8 @@ export class PanelManager {
         return text;
     }
 
+    // gets the updated row range to get as table is scrolled vertically (example "showing 1-10 of 50 entries")
     getScrollRange() {
-
         let rowRange: string;
         if (this.tableOptions.api) {
             const topPixel = this.tableOptions.api.getVerticalPixelRange().top;
@@ -46,10 +47,12 @@ export class PanelManager {
             let firstRow;
             let lastRow;
             this.tableOptions.api.getRenderedNodes().forEach(row => {
-                if (firstRow === undefined && row.rowTop >= topPixel) {
+                //if the top row is greater than the top pixel plus a little (to account rows that are just a little cut off) then broadcast its index in the status
+                if (firstRow === undefined && row.rowTop > topPixel - (row.rowHeight / 2)) {
                     firstRow = parseInt(row.rowIndex) + 1;
                 }
-                if ((row.rowTop + row.rowHeight) <= bottomPixel) {
+                //if the bottom row is less than the bottom pixel plus a little (to account rows that are just a little cut off) then broadcast its index in the status
+                if ((row.rowTop + row.rowHeight) < bottomPixel + (row.rowHeight / 2)) {
                     lastRow = parseInt(row.rowIndex) + 1;
                 }
             });
@@ -57,7 +60,7 @@ export class PanelManager {
             rowRange = firstRow.toString() + "-" + lastRow.toString();
         }
         else {
-            rowRange = '1-5'
+            rowRange = this.maximized ? '1-15' : '1-5';
         }
         if (this.panel.panelControls.find('.scrollRecords')[0]) {
             this.panel.panelControls.find('.scrollRecords')[0].innerHTML = rowRange;
@@ -89,10 +92,9 @@ export class PanelManager {
 
             let controls = this.header;
             controls = [new this.panel.container('<span style="flex: 1;"></span>'), ...controls];
-            controls = [new this.panel.container(`<div><h2><b>Features: ${layer.name}</b></h2><br><p><span class="scrollRecords">${this.getScrollRange()}</span> of <span class="filterRecords">${this.getFilterStatus()}</span></div>`), ...controls];
+            controls = [new this.panel.container(`<div style="padding-bottom :30px"><h2><b>Features: ${layer.name}</b></h2><br><p><span class="scrollRecords">${this.getScrollRange()}</span> of <span class="filterRecords">${this.getFilterStatus()}</span></div>`), ...controls];
             this.panel.controls = controls;
             this.panel.panelBody.css('padding-top', '16px');
-            this.panel.panelControls.css('padding-bottom', '30px');
             this.panel.panelControls.css('display', 'flex');
             this.panel.panelControls.css('align-items', 'center');
             this.currentTableLayer = layer;

--- a/enhancedTable/templates.ts
+++ b/enhancedTable/templates.ts
@@ -17,7 +17,7 @@ export const CLEAR_FILTERS_TEMPLATE = `
 <md-button
         ng-controller="ClearFiltersCtrl as ctrl"
         aria-label="{{ 't.table.filter.clear' | translate }}"
-        class="md-icon-button black"
+        class="md-icon-button black rv-button-24"
         rv-help="table-clear-button"
         ng-click="ctrl.clearFilters()"
         ng-disabled="!ctrl.anyFilters()">


### PR DESCRIPTION
Addresses:
- point 4 here: https://github.com/fgpv-vpgf/fgpv-vpgf/issues/3079
- point 3 here: https://github.com/fgpv-vpgf/fgpv-vpgf/issues/3077
   - sorting indicator done according to [Material Guidelines](https://material.io/design/components/data-tables.html#anatomy) (scroll down to sorting tool)

- and @AleksueiR's request for better padding/CSS layout for `enhancedTable` (now uses Flexbox instead of floats)

Testing info on sister PR over here: https://github.com/fgpv-vpgf/fgpv-vpgf/pull/3104