### PR TITLE
fix(enhancedTable): table works with legendAPI

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,4 @@
 ## Bug fixes
+- toggling `enhancedTable` is possible through the `Legend API`
 
 ## New Features

--- a/enhancedTable/index.ts
+++ b/enhancedTable/index.ts
@@ -31,6 +31,24 @@ class TableBuilder {
                 });
             }
         });
+
+        // toggle the enhancedTable if toggleDataTable is called from Legend API
+        this.mapApi.ui.configLegend._legendStructure._root._tableToggled.subscribe(legendBlock => {
+            if (legendBlock.blockType === 'node') {
+                // make sure the item clicked is a node, and not group or other
+                let layer;
+                if (legendBlock.parentLayerType === 'esriDynamic') {
+                    layer = this.mapApi.layers.allLayers.find(function (l) {
+                        return l.id === legendBlock.layerRecordId && l.layerIndex === parseInt(legendBlock.itemIndex);
+                    });
+                } else {
+                    layer = this.mapApi.layers.getLayersById(legendBlock.layerRecordId)[0];
+                }
+                if (layer) {
+                    this.mapApi.layers._click.next(layer);
+                }
+            }
+        });
     }
 
     createTable(attrBundle: AttrBundle) {
@@ -65,7 +83,7 @@ class TableBuilder {
                         headerName: '',
                         headerTooltip: '',
                         field: columnName,
-                        cellRenderer: function(cellImg) {
+                        cellRenderer: function (cellImg) {
                             return cellImg.value;
                         },
                         suppressSorting: true,

--- a/enhancedTable/tests/test.spec.js
+++ b/enhancedTable/tests/test.spec.js
@@ -2,10 +2,36 @@ const page = require('./et.page');
 
 describe('the enhancedTable panel', function () {
     beforeAll(function () {
-        browser.url('enhancedTable/samples/et-index.html');
+        browser.url('/enhancedTable/samples/et-index.html');
+
+        // used to check if window.RZ is defined
+        mApi = new Promise(function (resolve, reject) {
+            let rzWait = setInterval(function () {
+                browser.execute(function () {
+                    if (window.RZ === undefined) {
+                        return;
+                    }
+                    clearInterval(rzWait);
+                    resolve(window.RZ);
+                    return;
+                });
+            }, 100);
+        });
     });
 
     it('should open when a layer is clicked', function () {
-        expect(page.panel.waitForExist(3000)).toEqual(true);
+        mApi.then(function (RZ) {
+            page.open();
+            expect(browser.isVisible('#enhancedTable')).toEqual(true);
+        });
+    });
+
+    it('should open when datatable is toggled through the legend api', function () {
+        mApi.then(function (RZ) {
+            // test to see if the _tableToggled observable being fired leads to table being opened
+            let legendBlock = RZ.mapInstances[0].ui.configLegend.children[0]._legendBlock;
+            RZ.mapInstances[0].ui.configLegend._legendStructure._root._tableToggled.next(legendBlock);
+            expect(browser.isVisible('#enhancedTable')).toEqual(true);
+        });
     });
 });


### PR DESCRIPTION
## Link to issue number(s):
Closes: 
- https://github.com/fgpv-vpgf/fgpv-vpgf/issues/2931
- https://github.com/fgpv-vpgf/fgpv-vpgf/issues/2932
- https://github.com/fgpv-vpgf/fgpv-vpgf/issues/2933
- https://github.com/fgpv-vpgf/fgpv-vpgf/issues/2934

Sister PR to (on the viewer repo): 
- https://github.com/fgpv-vpgf/fgpv-vpgf/pull/3128

## Summary of the issue:
- We needed `legendapi` merged into `v3` asap for `enhancedTable` testing purposes (it is much easier to manipulate layers using `LegendItems` and `LegendGroups` instead of CSS selectors). 
- This PR makes `legendApi` compatible with the `enhancedTable` extension
- Also we fixed up [this test](https://github.com/fgpv-vpgf/plugins/compare/develop...ShrutiVellanki:legendapi?expand=1#diff-f1923b71550f5a6dc3eb14e3341d81a6L8) which always used to return true regardless of whether the table was open or not


## Description of how this pull request fixes the issue:
- Now the `_tableToggled` observable is set up and subscribed to: it fires when `legendItem.toggleDataTable()` is called
- A [test was added](https://github.com/fgpv-vpgf/plugins/compare/develop...ShrutiVellanki:legendapi?expand=1#diff-f1923b71550f5a6dc3eb14e3341d81a6R29) to verify that the observable works as intended

Thanks @dane-thomas for [this bit in the tests](https://github.com/fgpv-vpgf/plugins/compare/develop...ShrutiVellanki:legendapi?expand=1#diff-f1923b71550f5a6dc3eb14e3341d81a6R8) and help with proper table svg retrieval

## Testing:

-   [x] Test specs are up-to-date & cover all changes/additions made by this PR.
-   [x] `npm run test` passes locally.

<!-- Comment if additional testing was performed or if test specs are not suited to cover all cases. Provide links to external resources where appropriate.  -->

## Documentation

-   [x] Documentation is up-to-date - any changes or additions have been noted
-   [x] `changelog.md` has been updated

## Checklist

-   [x] PR has only one commit (squash otherwise)
-   [x] Commit message is descriptive
