### PR TITLE
fix(enhancedTable): layervisibility and table sync

### DIFF
--- a/bin/test/ramp.page.js
+++ b/bin/test/ramp.page.js
@@ -5,6 +5,24 @@ class RAMPage {
     get legendLayer() {
         return browser.element('rv-legend-control button');
     }
+
+    /**
+     * Returns the toggle visibility button of the first layer in the legend panel.
+     */
+    get toggleButton() {
+        return browser.element('.data-test-toggle-button');
+    }
+
+    get expandSymbologyStackButton() {
+        return browser.element('.rv-symbol-trigger');
+    }
+
+    /**
+     * Returns the first toggle symbology button of the first layer in the legend panel.
+     */
+    get toggleSymbologyButton() {
+        return browser.element('.data-test-symbol-toggle-button');
+    }
 }
 
 module.exports = RAMPage;

--- a/changelog.md
+++ b/changelog.md
@@ -1,4 +1,5 @@
 ## Bug fixes
 - toggling `enhancedTable` is possible through the `Legend API`
+- symbology toggles and layer visibility toggles sync up with `enhancedTable` rows and filter status
 
 ## New Features

--- a/enhancedTable/samples/ramp-config.json
+++ b/enhancedTable/samples/ramp-config.json
@@ -2,7 +2,12 @@
     "ui": {
         "navBar": {
             "zoom": "buttons",
-            "extra": ["fullscreen", "geoLocator", "home", "help"]
+            "extra": [
+                "fullscreen",
+                "geoLocator",
+                "home",
+                "help"
+            ]
         },
         "sideMenu": {
             "logo": true
@@ -75,7 +80,7 @@
                 "name": "root",
                 "children": [
                     {
-                        "layerId": "0"
+                        "layerId": "4"
                     },
                     {
                         "layerId": "1"
@@ -87,7 +92,7 @@
                         "layerId": "3"
                     },
                     {
-                        "layerId": "4"
+                        "layerId": "0"
                     },
                     {
                         "name": "child",

--- a/enhancedTable/tests/layerVisibility.spec.js
+++ b/enhancedTable/tests/layerVisibility.spec.js
@@ -1,0 +1,28 @@
+class RAMPage {
+    /**
+     * Returns the first layer button in the legend panel.
+     */
+    get legendLayer() {
+        return browser.element('rv-legend-control button');
+    }
+
+    /**
+     * Returns the toggle visibility button of the first layer in the legend panel.
+     */
+    get toggleButton() {
+        return browser.element('.data-test-toggle-button');
+    }
+
+    get expandSymbologyStackButton() {
+        return browser.element('.rv-symbol-trigger');
+    }
+
+    /**
+     * Returns the first toggle symbology button of the first layer in the legend panel.
+     */
+    get toggleSymbologyButton() {
+        return browser.element('.data-test-symbol-toggle-button');
+    }
+}
+
+module.exports = RAMPage;

--- a/enhancedTable/tests/symbolVisibility.spec.js
+++ b/enhancedTable/tests/symbolVisibility.spec.js
@@ -1,0 +1,59 @@
+const page = require('./et.page');
+jasmine.DEFAULT_TIMEOUT_INTERVAL = 20000;
+
+
+describe('the enhancedTable panel', function () {
+    beforeAll(function () {
+        browser.url('/enhancedTable/samples/et-index.html');
+
+        // when loading screen is finished RZ must be ready
+        browser.waitUntil(function () {
+            return browser.waitForVisible('.rv-loading-section', 25000, true);
+        }, 25000, 'expected the loading splash screen to be hidden after 25 seconds.');
+    });
+
+    it('should open when a layer is clicked', function () {
+        page.open();
+        expect(browser.waitForVisible('#enhancedTable', 20000)).toEqual(true);
+    });
+
+    it('should update rows and filter status when symbologies are toggled to invisible', function () {
+
+        // filter status and container height before toggling symbology
+        const prevHeight = browser.getElementSize('.ag-body-container', 'height');
+        const prevFilterStatus = browser.getText('.filterRecords');
+        const prevNumRows = parseInt(prevFilterStatus.slice(0, prevFilterStatus.indexOf(' ')));
+
+        // toggle symbology
+        page.expandSymbologyStack();
+        page.toggleSymbolVisibility();
+
+        // filter  status and container height after toggling symbology
+        const currFilterStatus = browser.getText('.filterRecords');
+        const currNumRows = parseInt(currFilterStatus.slice(0, currFilterStatus.indexOf(' ')));
+        const currHeight = browser.getElementSize('.ag-body-container', 'height');
+
+        // container height and number of rows after toggle should be less than before toggle
+        expect(currHeight).toBeLessThan(prevHeight);
+        expect(currNumRows).toBeLessThan(prevNumRows);
+    });
+
+    it('should update rows and filter status when symbologies are toggled to visible', function () {
+        // filter status and container height before toggling symbology
+        const prevHeight = browser.getElementSize('.ag-body-container', 'height');
+        const prevFilterStatus = browser.getText('.filterRecords');
+        const prevNumRows = parseInt(prevFilterStatus.slice(0, prevFilterStatus.indexOf(' ')));
+
+        // toggle symbology
+        page.toggleSymbolVisibility();
+
+        // filter  status and container height after toggling symbology
+        const currFilterStatus = browser.getText('.filterRecords');
+        const currNumRows = parseInt(currFilterStatus.slice(0, currFilterStatus.indexOf(' ')));
+        const currHeight = browser.getElementSize('.ag-body-container', 'height');
+
+        // container height and number of rows after toggle should be less than before toggle
+        expect(prevHeight).toBeLessThan(currHeight);
+        expect(prevNumRows).toBeLessThan(currNumRows);
+    });
+});


### PR DESCRIPTION
## Link to issue number(s):
Closes: https://github.com/fgpv-vpgf/fgpv-vpgf/issues/3159
Sister PR: https://github.com/fgpv-vpgf/fgpv-vpgf/pull/3168

### [TEST LINK](http://fgpv.cloudapp.net/demo/users/ShrutiVellanki/sync-symbols/dev/samples/index-enhanced-table.html)

## Summary of the issue:

Filter status and `enhancedTable` were out of sync with symbology and layer toggles.

## Description of how this pull request fixes the issue:
- Filter status and `enhancedTable` both react properly to symbology and layer toggles
- Open tables, toggle on/off symbologies, scroll, toggle on/off layer visibilities. The rows displayed/not displayed and filter status shown should make sense and match what would happen in the current table.


## Testing:

-   [x] Test specs are up-to-date & cover all changes/additions made by this PR.
-   [x] `npm run test` passes locally.

<!-- Comment if additional testing was performed or if test specs are not suited to cover all cases. Provide links to external resources where appropriate.  -->

## Documentation

-   ~[ ] Documentation is up-to-date - any changes or additions have been noted~
-   [x] `changelog.md` has been updated

## Checklist

-   [x] PR has only one commit (squash otherwise)
-   [x] Commit message is descriptive
