### PR TITLE
feat(enhancedTable): add selector filter

### DIFF
--- a/enhancedTable/index.ts
+++ b/enhancedTable/index.ts
@@ -4,7 +4,7 @@ import { PanelManager } from './panel-manager';
 import { DETAILS_AND_ZOOM } from './templates';
 import { ConfigManager, ColumnConfigManager } from './config-manager';
 import {
-    setUpDateFilter, setUpNumberFilter, setUpTextFilter
+    setUpDateFilter, setUpNumberFilter, setUpTextFilter, setUpSelectorFilter
 } from './custom-floating-filters';
 import { CustomHeader } from './custom-header';
 
@@ -112,7 +112,12 @@ class TableBuilder {
                             } else if (fieldInfo.type === DATE_TYPE) {
                                 setUpDateFilter(colDef, isStatic, this.mapApi);
                             } else if (fieldInfo.type === TEXT_TYPE && attrBundle.layer.table !== undefined) {
-                                setUpTextFilter(colDef, isStatic, isSelector, this.configManager.lazyFilterEnabled, this.configManager.searchStrictMatchEnabled, column.value);
+                                if (isSelector) {
+                                    setUpSelectorFilter(colDef, isStatic, column.value, this.tableOptions, this.mapApi);
+                                } else {
+                                    setUpTextFilter(colDef, isStatic, this.configManager.lazyFilterEnabled,
+                                        this.configManager.searchStrictMatchEnabled, column.value);
+                                }
                             }
                         }
 

--- a/enhancedTable/samples/ramp-config.json
+++ b/enhancedTable/samples/ramp-config.json
@@ -246,8 +246,7 @@
                 "table": {
                     "title": "Table Test Two - Custom Title",
                     "search": {
-                        "enabled": true,
-                        "value": "Ener"
+                        "enabled": true
                     },
                     "applyMap": false,
                     "columns": [

--- a/enhancedTable/templates.ts
+++ b/enhancedTable/templates.ts
@@ -166,3 +166,15 @@ export const CUSTOM_HEADER_TEMPLATE = (displayName: string) => `
     </div>
 </div>
 `;
+
+export const SELECTOR_FILTER_TEMPLATE = (value, isStatic) => {
+    if (isStatic === true) {
+        return `<md-select placeholder='selection' multiple="{{true}}" md-on-close='selectionChanged() style='height: 20px; opacity: 0.4; color: lightgrey' ng-model="selectedOptions" ng-disabled='true'>
+                         <md-option ng-value="option" ng-repeat="option in options">{{ option }}</md-option>
+                     </md-select>`;
+    } else {
+        return `<md-select placeholder='selection' multiple="{{true}}" style='height: 20px' md-on-close='selectionChanged()' ng-model="selectedOptions">
+                         <md-option ng-value="option" ng-repeat="option in options">{{ option }}</md-option>
+                     </md-select>`;
+    }
+}

--- a/enhancedTable/tests/et.page.js
+++ b/enhancedTable/tests/et.page.js
@@ -17,6 +17,14 @@ class Page extends RAMPage {
     get datepickerButton() {
         return browser.element('.md-datepicker-button');
     }
+
+    /**
+     * Returns the first selector drop down
+     */
+    get selectorDropDown() {
+        return browser.element('.md-select-value');
+    }
+
     /**
      * Return the element containing the dateInput
      */

--- a/enhancedTable/tests/filter-test.spec.js
+++ b/enhancedTable/tests/filter-test.spec.js
@@ -1,6 +1,6 @@
 const page = require('./et.page');
 
-describe('the enhancedTable filters', function() {
+describe('the enhancedTable filters', function () {
     beforeAll(function () {
         browser.url('enhancedTable/samples/et-test.html');
 
@@ -14,19 +14,23 @@ describe('the enhancedTable filters', function() {
         page.panel.waitForVisible(3000);
     });
 
-    it('should have a datefilter button', function() {
+    it('should have a datefilter button', function () {
         expect(page.datepickerButton.isExisting()).toEqual(true);
     });
 
-    it('should have a datefilter input', function() {
+    it('should have a datefilter input', function () {
         expect(page.dateInput.isExisting()).toEqual(true);
     });
 
-    it('should have a number filter with min', function() {
+    it('should have a selector dropdown', function () {
+        expect(page.selectorDropDown.isExisting()).toEqual(true);
+    });
+
+    it('should have a number filter with min', function () {
         expect(page.numberInput.min.isExisting()).toEqual(true);
     });
 
-    it('should have a number filter with max', function() {
+    it('should have a number filter with max', function () {
         expect(page.numberInput.max.isExisting()).toEqual(true);
     });
 });


### PR DESCRIPTION
## Link to issue number(s):
Helps close a part of: https://github.com/fgpv-vpgf/fgpv-vpgf/issues/3185

## Summary of the issue:
Selector column  was missing from `enhancedTable` even if it was specified in config

## Description of how this pull request fixes the issue:
Checks the config for selector filters and adds it creating a drop down menu with multiple select-able items.

### [TEST LINK](https://shrutivellanki.github.io/plugins/86c3672e4a55b77d652bdf12aede1afec26807cd/enhancedTable/samples/et-index.html)
### - Click first layer in legend, "Countries" column is an example of selector filter

## Testing:

-   [x] Test specs are up-to-date & cover all changes/additions made by this PR.
-   [x] `npm run test` passes locally.

<!-- Comment if additional testing was performed or if test specs are not suited to cover all cases. Provide links to external resources where appropriate.  -->

## Documentation

-   [x] Documentation is up-to-date - any changes or additions have been noted
-   ~[ ] `changelog.md` has been updated~

## Checklist

-   [x] PR has only one commit (squash otherwise)
-   [x] Commit message is descriptive
