### PR TITLE
feat(enhancedTable): table filters obey config

### DIFF
--- a/enhancedTable/index.ts
+++ b/enhancedTable/index.ts
@@ -110,13 +110,13 @@ class TableBuilder {
                             if (NUMBER_TYPES.indexOf(fieldInfo.type) > -1) {
                                 setUpNumberFilter(colDef, isStatic, column.value, this.tableOptions);
                             } else if (fieldInfo.type === DATE_TYPE) {
-                                setUpDateFilter(colDef, isStatic, this.mapApi);
+                                setUpDateFilter(colDef, isStatic, this.mapApi, column.value);
                             } else if (fieldInfo.type === TEXT_TYPE && attrBundle.layer.table !== undefined) {
                                 if (isSelector) {
                                     setUpSelectorFilter(colDef, isStatic, column.value, this.tableOptions, this.mapApi);
                                 } else {
                                     setUpTextFilter(colDef, isStatic, this.configManager.lazyFilterEnabled,
-                                        this.configManager.searchStrictMatchEnabled, column.value);
+                                        this.configManager.searchStrictMatchEnabled, column.value, this.mapApi);
                                 }
                             }
                         }
@@ -285,6 +285,14 @@ TableBuilder.prototype.translations = {
         detailsAndZoom: {
             details: 'Details',
             zoom: 'Zoom To Feature'
+        },
+        columnFilters: {
+            selector: 'selection',
+            date: {
+                min: 'date min',
+                max: 'date max'
+            },
+            text: 'text'
         }
     },
     'fr-CA': {
@@ -310,6 +318,14 @@ TableBuilder.prototype.translations = {
         detailsAndZoom: {
             details: 'Détails',
             zoom: "Zoom à l'élément"
+        },
+        columnFilters: {
+            selector: 'sélection',
+            date: {
+                min: 'date min',
+                max: 'date max'
+            },
+            text: 'texte'
         }
     }
 };

--- a/enhancedTable/panel-manager.ts
+++ b/enhancedTable/panel-manager.ts
@@ -263,7 +263,24 @@ export class PanelManager {
         this.mapApi.agControllerRegister('ClearFiltersCtrl', function () {
             // clear all column filters
             this.clearFilters = function () {
-                that.tableOptions.api.setFilterModel(null);
+
+                const columns = Object.keys(that.tableOptions.api.getFilterModel());
+                let newFilterModel = {};
+
+                // go through the columns in the current filter model
+                // save columns that have static filters
+                // because static filters remain intact even on clear all filters
+                let preservedColumns = columns.map(column => {
+                    const columnConfigManager = new ColumnConfigManager(that.configManager, column);
+                    if (columnConfigManager.isFilterStatic) {
+                        newFilterModel[column] = that.tableOptions.api.getFilterModel()[column];
+                        return column;
+                    }
+                });
+
+                newFilterModel = newFilterModel !== {} ? newFilterModel : null;
+
+                that.tableOptions.api.setFilterModel(newFilterModel);
             };
 
             // determine if any column filters are present

--- a/enhancedTable/samples/ramp-config.json
+++ b/enhancedTable/samples/ramp-config.json
@@ -173,23 +173,20 @@
                         {
                             "data": "OBJECTID",
                             "filter": {
-                                "type": "number",
-                                "value": "0,25"
+                                "type": "number"
                             }
                         },
                         {
                             "data": "Country",
                             "filter": {
-                                "type": "string",
-                                "value": "Canada"
+                                "type": "string"
                             },
                             "searchable": false
                         },
                         {
                             "data": "Latitude",
                             "filter": {
-                                "type": "number",
-                                "value": "48,49"
+                                "type": "number"
                             }
                         }
                     ]
@@ -377,7 +374,24 @@
                 "id": "9",
                 "name": "BadDates",
                 "layerType": "esriFeature",
-                "url": "https://section917.cloudapp.net/arcgis/rest/services/TestData/BadDates/MapServer/0"
+                "url": "http://section917.cloudapp.net/arcgis/rest/services/TestData/BadDates/MapServer/0",
+                "table": {
+                    "columns": [
+                        {
+                            "data": "iStartToParty",
+                            "title": "iStartToParty"
+                        },
+                        {
+                            "data": "iEndTheParty",
+                            "title": "iEndTheParty",
+                            "filter": {
+                                "type": "date",
+                                "value": "2017-02-01,2019-04-30",
+                                "static": true
+                            }
+                        }
+                    ]
+                }
             }
         ],
         "extentSets": [

--- a/enhancedTable/templates.ts
+++ b/enhancedTable/templates.ts
@@ -9,7 +9,6 @@ export const SEARCH_TEMPLATE = `
         <md-tooltip>{{ 't.search.placeholder' | translate }}</md-tooltip>
     </md-icon>
 </md-input-container>
-
 <span class="rv-table-divider"></span>
 `;
 
@@ -31,7 +30,6 @@ export const CLEAR_FILTERS_TEMPLATE = `
 export const COLUMN_VISIBILITY_MENU_TEMPLATE = `
 <md-menu-bar ng-controller="ColumnVisibilityMenuCtrl as ctrl">
     <md-menu md-position-mode="target-right target">
-
         <md-button
             aria-label="Menu"
             class="md-icon-button black rv-button-24"
@@ -39,7 +37,6 @@ export const COLUMN_VISIBILITY_MENU_TEMPLATE = `
             <md-tooltip>{{ 't.table.hideColumns' | translate }}</md-tooltip>
             <md-icon md-svg-src="community:format-list-checks"></md-icon>
         </md-button>
-
         <md-menu-content rv-trap-focus="{{::ctrl.appID}}" class="rv-menu rv-dense" width="4">
             <md-menu-item ng-repeat="col in ctrl.columnVisibilities">
                 <md-button ng-click="ctrl.toggleColumn(col)" aria-label="{{ col.title }} " md-prevent-menu-close="md-prevent-menu-close">
@@ -55,50 +52,39 @@ export const COLUMN_VISIBILITY_MENU_TEMPLATE = `
 export const MENU_TEMPLATE = `
 <md-menu-bar ng-controller="MenuCtrl as ctrl">
     <md-menu md-position-mode="target-right target">
-
         <md-button
             aria-label="Menu"
             class="md-icon-button black rv-button-24"
             ng-click="$mdOpenMenu($event)">
             <md-icon md-svg-src="navigation:more_vert"></md-icon>
         </md-button>
-
         <md-menu-content rv-trap-focus="{{::ctrl.appID}}" class="rv-menu rv-dense" width="5">
-
             <md-menu-item type="radio" ng-model="ctrl.maximized" value="false" ng-click="ctrl.setSize(ctrl.maximized)" rv-right-icon="none">
                 {{ 't.menu.split' | translate }}
             </md-menu-item>
-
             <md-menu-item type="radio" ng-model="ctrl.maximized" value="true" ng-click="ctrl.setSize(ctrl.maximized)" rv-right-icon="none">
                 {{ 't.menu.max' | translate }}
             </md-menu-item>
-
             <md-menu-divider class="rv-lg"></md-menu-divider>
-
             <md-menu-item type="checkbox" ng-model="self.filter.isActive" ng-click="self.applyFilter(self.filter.isActive)" rv-right-icon="community:filter">
                 {{ 't.menu.filter.extent' | translate }}
             </md-menu-item>
-
             <md-menu-item type="checkbox" ng-model="ctrl.showFilter" ng-click="ctrl.toggleFilters()" rv-right-icon="community:filter">
                 {{ 't.menu.filter.show' | translate }}
             </md-menu-item>
-
             <md-menu-divider></md-menu-divider>
-
             <md-menu-item>
                 <md-button ng-click="ctrl.print()">
                     <md-icon md-svg-icon="action:print"></md-icon>
                     {{ 't.menu.print' | translate }}
                 </md-button>
             </md-menu-item>
-
             <md-menu-item>
                 <md-button ng-click="ctrl.export()">
                     <md-icon md-svg-icon="editor:insert_drive_file"></md-icon>
                     {{ 't.menu.export' | translate }}
                 </md-button>
             </md-menu-item>
-
         </md-menu-content>
     </md-menu>
 </md-menu-bar>
@@ -119,36 +105,38 @@ export const ZOOM_TEMPLATE = (rowIndex) =>
     </button>`;
 
 export const NUMBER_FILTER_TEMPLATE = (value, isStatic) => {
-    value = (value === undefined) ? '' : value;
+    const minVal = (value === undefined) ? '' : parseInt(value.split(',')[0]);
+    const maxVal = (value === undefined) ? '' : parseInt(value.split(',')[1]);
     if (isStatic === false) {
-        return `<input class="rv-min" style="width:50%" type="text" placeholder="MIN" value='${value}'/>
-         <input class="rv-max" style="width:50%" type="text" placeholder="MAX" value='${value}'/>`;
-    } else {
-        return `<input class="rv-min" style="width:45%; border-bottom: lightgrey dashed 1px" type="text" placeholder="MIN" value='${value}' disabled/>
-         <input class="rv-max" style="width:45%; border-bottom: lightgrey dashed 1px" type="text" placeholder="MAX" value='${value}' disabled/>`;
+        return `<input class="rv-min" style="width:50%" type="text" placeholder="min" value='${minVal}'/>
+         <input class="rv-max" style="width:50%" type="text" placeholder="max" value='${maxVal}'/>`;
     }
+    return `<input class="rv-min" style="width:45%; opacity: 0.4" type="text" placeholder="min" value='${minVal}' disabled/>
+         <input class="rv-max" style="width:45%; opacity: 0.4" type="text" placeholder="max" value='${maxVal}' disabled/>`;
+
 }
 
 export const DATE_FILTER_TEMPLATE = (value, isStatic) => {
-    value = (value === undefined) ? '' : value;
 
-    if (isStatic === false) {
+    if (isStatic === true) {
         return `<span>
-                 <md-datepicker ng-change="minChanged()" ng-model="min"></md-datepicker>
-                 <md-datepicker ng-change="maxChanged()" ng-model="max"></md-datepicker>
+                 <md-datepicker md-placeholder="{{ 't.columnFilters.date.min' | translate }}" ng-model='min' ng-change="minChanged()" ng-disabled='true' style='opacity: 0.4'></md-datepicker>
+                 <md-datepicker md-placeholder="{{ 't.columnFilters.date.max' | translate }}" ng-model='max' ng-change="maxChanged()" ng-disabled='true' style='opacity: 0.4'></md-datepicker>
              </span>`;
-    } else {
-        /*return `<span>
-                <md-datepicker ng-change="minChanged()" ng-model="min" disabled></md-datepicker>
-                <md-datepicker ng-change="maxChanged()" ng-model="max" disabled></md-datepicker>
-            </span>`;*/
     }
-
+    return `<span>
+                 <md-datepicker md-placeholder="{{ 't.columnFilters.date.min' | translate }}" ng-model='min' ng-change="minChanged()"></md-datepicker>
+                 <md-datepicker md-placeholder="{{ 't.columnFilters.date.max' | translate }}" ng-model='max' ng-change="maxChanged()"></md-datepicker>
+             </span>`;
 }
 
-export const STATIC_TEXT_FIELD_DISABLED = (value) => {
+export const TEXT_FILTER_TEMPLATE = (value, isStatic) => {
     value = (value === undefined) ? '' : value;
-    return `<input type="text" disabled style ='border-bottom: dashed lightgrey 1px' placeholder='${value}'/>`
+
+    if (isStatic) {
+        return `<input class='rv-input' type="text" placeholder="{{ 't.columnFilters.text' | translate }}"' disabled style='opacity: 0.4' value='${value}'/>`
+    }
+    return `<input class='rv-input' ng-model='input' ng-change='inputChanged()' type="text" placeholder="{{ 't.columnFilters.text' | translate }}"' value='${value}'/>`
 };
 
 export const CUSTOM_HEADER_TEMPLATE = (displayName: string) => `
@@ -169,11 +157,11 @@ export const CUSTOM_HEADER_TEMPLATE = (displayName: string) => `
 
 export const SELECTOR_FILTER_TEMPLATE = (value, isStatic) => {
     if (isStatic === true) {
-        return `<md-select placeholder='selection' multiple="{{true}}" md-on-close='selectionChanged() style='height: 20px; opacity: 0.4; color: lightgrey' ng-model="selectedOptions" ng-disabled='true'>
+        return `<md-select placeholder="{{ 't.columnFilters.selector' | translate }}" multiple="{{true}}" md-on-close='selectionChanged() style='height: 20px; opacity: 0.4; color: lightgrey' ng-model="selectedOptions" ng-disabled='true'>
                          <md-option ng-value="option" ng-repeat="option in options">{{ option }}</md-option>
                      </md-select>`;
     } else {
-        return `<md-select placeholder='selection' multiple="{{true}}" style='height: 20px' md-on-close='selectionChanged()' ng-model="selectedOptions">
+        return `<md-select placeholder="{{ 't.columnFilters.selector' | translate }}" multiple="{{true}}" style='height: 20px' md-on-close='selectionChanged()' ng-model="selectedOptions">
                          <md-option ng-value="option" ng-repeat="option in options">{{ option }}</md-option>
                      </md-select>`;
     }


### PR DESCRIPTION
## Link to issue number(s):
Closes: https://github.com/fgpv-vpgf/fgpv-vpgf/issues/3185

## Summary of the issue:
- When default filters were on config, `enhancedTable` didn't have them automatically applied
- placeholder values were not available for all filter types
- not all placeholders had proper translations
- no consistent theme for disabled filters.

## Description of how this pull request fixes the issue:

- default values for all filter types (string, selector, date and number)
- placeholders added for text filters and date filters
- placeholders have french translations
- static filters made to look uniform accross different filter types (white overlay)

## [Testing:](https://shrutivellanki.github.io/plugins/021ccc70258f1ed1431c7f647c550318fcd492ec/enhancedTable/samples/et-index.html)

Look at the following layers for each filter type (some with default values and static filters)

| Layer          | Column Filter Types          
| ------------- |:-------------:| 
| No initial filter 2        | number, selector (default values)  |
| 2 column filters        | number(default values), string(default values)   |
| 3 column filters         |searchable false  |
| With filter but not applied to map         | string (default value, static)   |
| 3 columns with 2 filteres        | number (default values, static),  string (default value)   | 
| Bad Dates         | date filter (default values, static)   | 

Note: bad dates won't load here, but it will locally. This is how it looks (iEndTheParty is default, disabled)
![image](https://user-images.githubusercontent.com/25359812/50785630-450ae800-127f-11e9-9ba3-1d6cfc48ffa2.png)


-   [x] Test specs are up-to-date & cover all changes/additions made by this PR.
-   [x] `npm run test` passes locally.

<!-- Comment if additional testing was performed or if test specs are not suited to cover all cases. Provide links to external resources where appropriate.  -->

## Documentation

-   [x] Documentation is up-to-date - any changes or additions have been noted
-   ~[ ] `changelog.md` has been updated~

## Checklist

-   [x] PR has only one commit (squash otherwise)
-   [x] Commit message is descriptive
<!-- meeseeks:start --> 



## PR Status
| Check | Status |
| -------------------	| ------------	|
| PR has one commit | :heavy_check_mark:        	|
| UI testing passed | :x: [results](https://plugins.fgpv-vpgf.com/test-results/2d4464ecfed995287b4f81836f5a95fd199988db-result.html)	|
<!-- meeseeks:end -->