### PR TITLE
Table state on reload/reopen, fix details and zoom bug, default global filter text shows

### DIFF
--- a/bin/test/ramp/rv-styles.css
+++ b/bin/test/ramp/rv-styles.css
@@ -18609,14 +18609,18 @@ Obviously you need some kind of rules and criteria:
         background-color: #9E9E9E !important;
         border-color: #9E9E9E !important; }
     [is=rv-map] .rv-slider .rv-slider-footer, .fgpv .rv-slider .rv-slider-footer {
-      display: flex;
       padding-left: 32px;
       top: -12px;
       position: relative;
       margin-bottom: -13px; }
-      [is=rv-map] .rv-slider .rv-slider-footer .rv-slider-changeat .rv-control-name, .fgpv .rv-slider .rv-slider-footer .rv-slider-changeat .rv-control-name {
-        text-transform: lowercase; }
+      [is=rv-map] .rv-slider .rv-slider-footer .rv-slider-changeat, .fgpv .rv-slider .rv-slider-footer .rv-slider-changeat {
+        display: inline;
+        margin: 0 4px;
+        padding: 0 4px; }
+        [is=rv-map] .rv-slider .rv-slider-footer .rv-slider-changeat .rv-control-name, .fgpv .rv-slider .rv-slider-footer .rv-slider-changeat .rv-control-name {
+          text-transform: lowercase; }
       [is=rv-map] .rv-slider .rv-slider-footer rv-legend-control, .fgpv .rv-slider .rv-slider-footer rv-legend-control {
+        display: inline;
         padding: 0;
         margin: 0 4px; }
         [is=rv-map] .rv-slider .rv-slider-footer rv-legend-control .rv-link-button, .fgpv .rv-slider .rv-slider-footer rv-legend-control .rv-link-button {
@@ -18629,6 +18633,13 @@ Obviously you need some kind of rules and criteria:
           margin: 0;
           padding: 0 4px;
           height: 20px; }
+          [is=rv-map] .rv-slider .rv-slider-footer rv-legend-control .rv-link-button span, .fgpv .rv-slider .rv-slider-footer rv-legend-control .rv-link-button span {
+            text-align: left;
+            width: 250px;
+            display: block;
+            white-space: nowrap;
+            overflow: hidden;
+            text-overflow: ellipsis; }
   [is=rv-map] rv-settings .rv-subheader, .fgpv rv-settings .rv-subheader {
     border: none !important; }
   [is=rv-map] rv-settings .rv-settings-divider, .fgpv rv-settings .rv-settings-divider {
@@ -18669,11 +18680,15 @@ Obviously you need some kind of rules and criteria:
     left: 280px;
     padding-bottom: 10px !important; }
   [is=rv-map] rv-settings .rv-input-footer, .fgpv rv-settings .rv-input-footer {
-    display: flex;
     margin-top: 10px; }
-    [is=rv-map] rv-settings .rv-input-footer .rv-input-changeat .rv-control-name, .fgpv rv-settings .rv-input-footer .rv-input-changeat .rv-control-name {
-      text-transform: lowercase; }
+    [is=rv-map] rv-settings .rv-input-footer .rv-input-changeat, .fgpv rv-settings .rv-input-footer .rv-input-changeat {
+      display: inline;
+      margin: 0 4px;
+      padding: 0 4px; }
+      [is=rv-map] rv-settings .rv-input-footer .rv-input-changeat .rv-control-name, .fgpv rv-settings .rv-input-footer .rv-input-changeat .rv-control-name {
+        text-transform: lowercase; }
     [is=rv-map] rv-settings .rv-input-footer rv-legend-control, .fgpv rv-settings .rv-input-footer rv-legend-control {
+      display: inline;
       padding: 0;
       margin: 0 4px; }
       [is=rv-map] rv-settings .rv-input-footer rv-legend-control .rv-link-button, .fgpv rv-settings .rv-input-footer rv-legend-control .rv-link-button {
@@ -18686,6 +18701,13 @@ Obviously you need some kind of rules and criteria:
         margin: 0;
         padding: 0 4px;
         height: 20px; }
+        [is=rv-map] rv-settings .rv-input-footer rv-legend-control .rv-link-button span, .fgpv rv-settings .rv-input-footer rv-legend-control .rv-link-button span {
+          text-align: left;
+          width: 250px;
+          display: block;
+          white-space: nowrap;
+          overflow: hidden;
+          text-overflow: ellipsis; }
   [is=rv-map] rv-toc .rv-content-pane .rv-content, .fgpv rv-toc .rv-content-pane .rv-content {
     padding: 0; }
   [is=rv-map] .rv-toc, .fgpv .rv-toc {

--- a/enhancedTable/config-manager.ts
+++ b/enhancedTable/config-manager.ts
@@ -37,7 +37,7 @@ export class ConfigManager {
      * Helper method to tableInit
      */
     maximize(): void {
-        const maximized = this.tableConfig.maximize || false;
+        const maximized = this.panelManager.panelStateManager.maximized;
         this.panelManager.maximized = maximized;
         this.panelManager.setSize();
     }
@@ -50,18 +50,16 @@ export class ConfigManager {
     }
 
     /**
-     * Set default search parameter for global search if defined in the config.
+     * Gets default search parameter for global search if defined in the config.
      */
-    setDefaultSearchParameter(): void {
-        const searchText = this.tableConfig.search.value
-        if (searchText !== undefined && this.globalSearchEnabled) {
-            let enhancedTable = document.getElementById('enhancedTable');
+    get defaultGlobalSearch(): string {
+        const searchText = this.tableConfig.search.value === undefined ? '' : this.tableConfig.search.value;
+        return searchText;
+    }
 
-            //TODO FIXME: the input isn't getting updated in the input field, but getting updated in the DOM!
-            let input = <HTMLInputElement>enhancedTable.querySelector('.md-input');
-            input.value = searchText;
-
-            this.panelManager.tableOptions.api.setQuickFilter(searchText);
+    setDefaultGlobalSearchFilter(): void {
+        if (this.globalSearchEnabled) {
+            this.panelManager.tableOptions.api.setQuickFilter(this.defaultGlobalSearch);
         }
     }
 

--- a/enhancedTable/details-and-zoom-buttons.ts
+++ b/enhancedTable/details-and-zoom-buttons.ts
@@ -20,9 +20,13 @@ export class DetailsAndZoomButtons {
             let proxy = that.legendBlock.proxyWrapper.proxy;
 
             // opens the details panel corresponding to the row where the details button is found
-            this.openDetails = function (rowIndex) {
+            this.openDetails = function (oid) {
                 let data = proxy.attribs.then(function (attribs) {
-                    const attributes = attribs.features[rowIndex].attributes;
+                    const attributes = attribs.features.find(attrib => {
+                        if (attrib.attributes.OBJECTID === oid) {
+                            return attrib.attributes;
+                        }
+                    }).attributes;
                     let symbology = attributes['rvSymbol'];
                     let dataObj = [];
                     const map = that.mapApi.mapI;
@@ -53,7 +57,7 @@ export class DetailsAndZoomButtons {
                     let detailsObj = {
                         isLoading: false,
                         data: [{
-                            name: proxy.getFeatureName(rowIndex, attributes),
+                            name: proxy.getFeatureName(oid, attributes),
                             data: proxy.attributesToDetails(attributes, dataObj),
                             oid: attributes[proxy.oidField],
                             symbology: [{ svgcode: symbology }]
@@ -75,15 +79,12 @@ export class DetailsAndZoomButtons {
             };
 
             // determine if any column filters are present
-            this.zoomToFeature = function (rowIndex) {
-                proxy.attribs.then(function (attribs) {
-                    let oid = attribs.features[rowIndex].attributes[proxy.oidField];
-                    const map = that.mapApi.mapI;
-                    //set appropriate offset for point before zooming
-                    (that.panelManager.maximized || that.panelManager.isMobile()) ? that.mapApi.mapI.externalPanel($('#enhancedTable')) : that.mapApi.mapI.externalPanel(undefined);
-                    let offset = (that.panelManager.maximized || that.panelManager.isMobile()) ? { x: 0, y: 0 } : { x: 0.10416666666666667, y: 0.24464094319399785 };
-                    map.zoomToFeature(proxy, oid, offset);
-                });
+            this.zoomToFeature = function (oid) {
+                const map = that.mapApi.mapI;
+                //set appropriate offset for point before zooming
+                (that.panelManager.maximized || that.panelManager.isMobile()) ? that.mapApi.mapI.externalPanel($('#enhancedTable')) : that.mapApi.mapI.externalPanel(undefined);
+                let offset = (that.panelManager.maximized || that.panelManager.isMobile()) ? { x: 0, y: 0 } : { x: 0.10416666666666667, y: 0.24464094319399785 };
+                map.zoomToFeature(proxy, oid, offset);
             };
         });
     }

--- a/enhancedTable/panel-rows-manager.ts
+++ b/enhancedTable/panel-rows-manager.ts
@@ -10,8 +10,10 @@ export class PanelRowsManager {
         this.tableOptions = panelManager.tableOptions;
     }
 
-    // table is set up according to layer visibiltiy on open
-    // observers are set up in case of change to layer visibility or symbol visibility
+    /**
+    * Table is set up according to layer visibiltiy on open
+    * Observers are set up in case of change to layer visibility or symbol visibility
+    */
     initObservers() {
         this.legendBlock = this.panelManager.legendBlock;
         this.currentTableLayer = this.panelManager.currentTableLayer;
@@ -20,8 +22,10 @@ export class PanelRowsManager {
         this.symbolVisibilityObserver();
     }
 
-    // helper method to initTableRowVisibility
-    // sets table filters based on table visibility on open
+    /**
+    * Helper method to initTableRowVisibility
+    * Sets table filters based on table visibility on open
+    */
     initialFilterSettings() {
         if (!this.currentTableLayer.visibility) {
             // if  layer is invisible, table needs to show zero entries
@@ -34,9 +38,20 @@ export class PanelRowsManager {
         }
     }
 
-    // helper method to initObservers
-    // sets up initial row visibility based on layer visibility and symbology visibilities on open
+    /**
+     * Helper method to initObservers
+     * Sets up initial row visibility based on layer visibility and symbology visibilities on open
+     */
     initTableRowVisibility() {
+
+        if (this.legendBlock.visibility === false) {
+            // if the legendBlock is invisible on table open, table rows should be empty
+            if (this.legendBlock.parent.blockType === 'set') {
+                this.invisibleSetFilterSettings();
+            } else {
+                this.invisibileNodeFilterSettings();
+            }
+        }
         if (this.tableOptions.api) {
             let that = this;
 
@@ -55,23 +70,28 @@ export class PanelRowsManager {
         }
     }
 
-    // helper method to layerVisibilityObserver
-    // saves table filters for when a LegendNode gets toggled to invisible
+    /**
+    * Helper method to layerVisibilityObserver
+    * Saves table filters for when a LegendNode gets toggled to invisible
+    */
     invisibileNodeFilterSettings() {
         //if set to invisible: store current filter, and then filter out all visible rows
-        this.tableOptions.api.validOIDs = undefined;
-        this.storedFilter = this.tableOptions.api.getFilterModel();
-        this.prevQuickFilterText = this.quickFilterText;
-        this.tableOptions.api.setQuickFilter('1=2');
-        this.quickFilterText = '1=2';
-        this.visibility = false;
-        this.tableOptions.api.selectAllFiltered();
-        this.panelManager.panelStatusManager.getFilterStatus();
-        this.tableOptions.api.deselectAllFiltered();
+        if (this.quickFilterText !== '1=2') {
+            this.tableOptions.api.validOIDs = undefined;
+            this.prevQuickFilterText = this.quickFilterText;
+            this.tableOptions.api.setQuickFilter('1=2');
+            this.quickFilterText = '1=2';
+            this.visibility = false;
+            this.tableOptions.api.selectAllFiltered();
+            this.panelManager.panelStatusManager.getFilterStatus();
+            this.tableOptions.api.deselectAllFiltered();
+        }
     }
 
-    // helper method to layerVisibilityObserver
-    // resets/updates table filters for when a LegendNode gets toggled to visible
+    /**
+    * Helper method to layerVisibilityObserver
+    * Resets/updates table filters for when a LegendNode gets toggled to visible
+    */
     visibileNodeFilterSettings() {
         // if set to visibile: show all rows and clear external filter (because all symbologies will be checked in)
         if (this.prevQuickFilterText !== undefined && this.prevQuickFilterText !== '1=2') {
@@ -79,8 +99,8 @@ export class PanelRowsManager {
             this.quickFilterText = this.prevQuickFilterText;
         }
         else {
-            this.tableOptions.api.setQuickFilter('');
-            this.quickFilterText = '';
+            this.tableOptions.api.setQuickFilter(this.panelManager.searchText);
+            this.quickFilterText = this.panelManager.searchText;
         }
         this.externalFilter = false;
         this.tableOptions.api.onFilterChanged();
@@ -95,17 +115,20 @@ export class PanelRowsManager {
         this.tableOptions.api.deselectAllFiltered();
     }
 
-    // helper method to layerVisibilityObserver
-    // saves table filters for when a LegendSet gets toggled to invisible
+    /**
+    * Helper method to layerVisibilityObserver
+    * Saves table filters for when a LegendSet gets toggled to invisible
+    */
     invisibleSetFilterSettings() {
-        this.storedFilter = this.tableOptions.api.getFilterModel();
         this.tableOptions.api.setQuickFilter('1=2');
         this.quickFilterText = '1=2';
         this.visibility = false;
     }
 
-    // helper method to layerVisibilityObserver
-    // resets/updates table filters for when a LegendSet gets toggled to visible
+    /**
+    * Helper method to layerVisibilityObserver
+    * Resets/updates table filters for when a LegendSet gets toggled to visible
+    */
     visibleSetFilterSettings() {
         this.tableOptions.api.setQuickFilter('');
         this.quickFilterText = '';
@@ -117,8 +140,10 @@ export class PanelRowsManager {
         this.visibility = true;
     }
 
-    // helper method to initObservers
-    // saves table and update table filter states upon layer visibilty changes
+    /**
+    * Helper method to initObservers
+    * Saves table and update table filter states upon layer visibilty changes
+    */
     layerVisibilityObserver() {
         this.legendBlock.visibilityChanged.subscribe(visibility => {
             if (this.tableOptions.api
@@ -142,8 +167,10 @@ export class PanelRowsManager {
         });
     }
 
-    // helper method to multiple methods
-    // tricks ag-grid into updating filter status by selecting all filtered rows
+    /**
+    * Helper method to multiple methods
+    * Tricks ag-grid into updating filter status by selecting all filtered rows
+    */
     updateGridFilters() {
         this.tableOptions.api.onFilterChanged();
         this.tableOptions.api.selectAllFiltered();
@@ -151,8 +178,10 @@ export class PanelRowsManager {
         this.tableOptions.api.deselectAllFiltered();
     }
 
-    // helper method to symboLVisibilityObserver
-    // updates table filter states
+    /**
+    * Helper method to symbolVisibilityObserver
+    * Updates table filter states
+    */
     setFiltersOnSymbolUpdate() {
         if (this.quickFilterText === '1=2') {
             // if this is a symbol being toggled on which sets layer visibility to true
@@ -174,8 +203,10 @@ export class PanelRowsManager {
         }
     }
 
-    // helper method to initObservers
-    // saves table and update table filter states upon symbol visibilty changes
+    /**
+    * Helper method to initObservers
+    * Saves table and updates table filter states upon symbol visibilty changes
+    */
     symbolVisibilityObserver() {
         // when one of the symbols are toggled on/off, filter the table
         this.legendBlock.symbolVisibilityChanged.subscribe(visibility => {

--- a/enhancedTable/panel-state-manager.ts
+++ b/enhancedTable/panel-state-manager.ts
@@ -1,0 +1,42 @@
+import { PanelManager } from './panel-manager';
+
+/**
+ * Saves relevant enhancedTable states so that it can be reset on reload/reopen. A PanelStateManager is linked to a BaseLayer.
+ * setters are called each time enhancedTable states are updated, getters are called each time enhancedTable is reloaded/reopened.
+ * States to save and reset:
+ *      - displayed rows (on symbology and layer visibility updates)
+ *      - column filters
+ *      - whether table maximized is in maximized or split view
+ */
+export class PanelStateManager {
+
+    constructor(baseLayer: any) {
+        this.baseLayer = baseLayer;
+        this.isMaximized = baseLayer.table.maximize || false;
+        this.columnFilters = {};
+    }
+
+    getColumnFilter(colDefField: any): any {
+        return this.columnFilters[colDefField];
+    }
+
+    setColumnFilter(colDefField, filterValue): void {
+        this.columnFilters[colDefField] = filterValue;
+    }
+
+    set maximized(maximized: boolean) {
+        this.isMaximized = maximized;
+    }
+
+    get maximized(): boolean {
+        return this.isMaximized;
+    }
+
+}
+
+export interface PanelStateManager {
+    baseLayer: any;
+    isMaximized: boolean;
+    rows: any;
+    columnFilters: any;
+}

--- a/enhancedTable/samples/ramp-config.json
+++ b/enhancedTable/samples/ramp-config.json
@@ -125,6 +125,8 @@
                 "layerType": "esriFeature",
                 "table": {
                     "applyMap": true,
+                    "lazyFilter": true,
+                    "searchStrictMatch": true,
                     "columns": [
                         {
                             "data": "OBJECTID",
@@ -231,8 +233,7 @@
                         "enabled": false
                     },
                     "lazyFilter": true,
-                    "applyMap": true,
-                    "searchStrictMatch": true
+                    "applyMap": true
                 }
             },
             {
@@ -243,7 +244,7 @@
                 "table": {
                     "title": "Table Test Two - Custom Title",
                     "search": {
-                        "enabled": true
+                        "value": "Ener"
                     },
                     "applyMap": false,
                     "columns": [
@@ -267,8 +268,7 @@
                             }
                         },
                         {
-                            "data": "Operator",
-                            "visible": false
+                            "data": "Operator"
                         }
                     ]
                 }

--- a/enhancedTable/templates.ts
+++ b/enhancedTable/templates.ts
@@ -117,23 +117,23 @@ export const RECORD_COUNT_TEMPLATE = `
     <span class="filterRecords">{{ filterRecords }}</span>
 </p>`;
 
-export const DETAILS_TEMPLATE = (rowIndex) =>
-    `<button ng-controller='DetailsAndZoomCtrl as ctrl' ng-click='ctrl.openDetails(${rowIndex})' md-ink-ripple class='md-icon-button rv-icon-16 rv-button-24 md-button ng-scope enhanced-table-details' aria-label="{{ 't.detailsAndZoom.details' | translate }}">
+export const DETAILS_TEMPLATE = (oid) =>
+    `<button ng-controller='DetailsAndZoomCtrl as ctrl' ng-click='ctrl.openDetails(${oid})' md-ink-ripple class='md-icon-button rv-icon-16 rv-button-24 md-button ng-scope enhanced-table-details' aria-label="{{ 't.detailsAndZoom.details' | translate }}">
         <md-icon md-svg-src="action:description" aria-hidden='false' class='ng-scope' role='img'>
             <md-tooltip  md-direction="top">{{ 't.detailsAndZoom.details' | translate }}</md-tooltip>
         </md-icon>
     </button>`;
 
-export const ZOOM_TEMPLATE = (rowIndex) =>
-    `<button ng-controller='DetailsAndZoomCtrl as ctrl' ng-click='ctrl.zoomToFeature(${rowIndex})'  md-ink-ripple class='md-icon-button rv-icon-16 rv-button-24 md-button ng-scope enhanced-table-zoom' aria-label="{{ 't.detailsAndZoom.zoom' | translate }}">
+export const ZOOM_TEMPLATE = (oid) =>
+    `<button ng-controller='DetailsAndZoomCtrl as ctrl' ng-click='ctrl.zoomToFeature(${oid})'  md-ink-ripple class='md-icon-button rv-icon-16 rv-button-24 md-button ng-scope enhanced-table-zoom' aria-label="{{ 't.detailsAndZoom.zoom' | translate }}">
         <md-icon md-svg-src="action:zoom_in" aria-hidden='false'>
             <md-tooltip  md-direction="top">{{ 't.detailsAndZoom.zoom' | translate }}</md-tooltip>
         </md-icon>
     </button>`;
 
 export const NUMBER_FILTER_TEMPLATE = (value, isStatic) => {
-    const minVal = (value === undefined) ? '' : parseInt(value.split(',')[0]);
-    const maxVal = (value === undefined) ? '' : parseInt(value.split(',')[1]);
+    const minVal = (value === undefined) ? '' : (value.split(',')[0] !== '') ? parseInt(value.split(',')[0]) : '';
+    const maxVal = (value === undefined) ? '' : (value.split(',')[1] !== '') ? parseInt(value.split(',')[1]) : '';
     if (isStatic === false) {
         return `<input class="rv-min" style="width:50%" type="text" placeholder="min" value='${minVal}'/>
          <input class="rv-max" style="width:50%" type="text" placeholder="max" value='${maxVal}'/>`;


### PR DESCRIPTION
**NOTE: The reload button itself doesn't toggle / refresh the table. This will come in a future PR addressing bug  fixes**

## Link to issue number(s):

Closes: 
- https://github.com/fgpv-vpgf/fgpv-vpgf/issues/3214
- https://github.com/fgpv-vpgf/fgpv-vpgf/issues/3234
- https://github.com/fgpv-vpgf/fgpv-vpgf/issues/3236

## Summary of the issue:

- When `enhancedTables`were reloaded/reopened, they did not preserve table states.
- Table details and zoom fail for filtered tables (returns wrong point)
- Selector filter would appear to fail because default global filter search text was not showing

## Description of how this pull request fixes the issue:

#### 1. Required Table States are Preserved
 Required table states:
- visibility (layer and symbology)
- filter status
- column filters
- whether table is maximized/split view

#### 2. Details and Zoom work for filtered and non-filtered tables

#### 3. Pre-defined global filter text shows up in global search (causes less confusion)
![image](https://user-images.githubusercontent.com/25359812/51138734-dd6d1380-180f-11e9-9c70-a7f41fc1e57c.png)



## [Testing:](https://shrutivellanki.github.io/plugins/cef8121c038494c328faa01072310df37aa8320c/enhancedTable/samples/et-index.html)

-   [x] Test specs are up-to-date & cover all changes/additions made by this PR.
-   [x] `npm run test` passes locally.

<!-- Comment if additional testing was performed or if test specs are not suited to cover all cases. Provide links to external resources where appropriate.  -->

## Documentation

-   [x] Documentation is up-to-date - any changes or additions have been noted
-   [ ] `changelog.md` has been updated

## Checklist

-   [x] PR has only one commit (squash otherwise)
-   [x] Commit message is descriptive
