### PR TITLE
feat(enhancedTable): close table on layer reload

### DIFF
--- a/enhancedTable/panel-manager.ts
+++ b/enhancedTable/panel-manager.ts
@@ -27,6 +27,15 @@ export class PanelManager {
         this.panel.element[0].classList.add('default');
         this.panel.element[0].addEventListener('focus', (e: any) => scrollIntoView(e, this.panel.element[0]), true);
 
+        // Enhance panel's close function so panel close button destroys table properly
+        let close = this.panel.close.bind(this.panel);
+        this.panel.close = () => {
+            this.panel.element[0].removeEventListener('focus', (e: any) => scrollIntoView(e, this.panel.element[0]), true);
+            this.gridBody.removeEventListener('focus', (e: any) => tabToGrid(e, this.tableOptions, this.lastFilter), false);
+            this.currentTableLayer = undefined;
+            close();
+        }
+
         // add mobile menu to the dom
         let mobileMenuTemplate = $(MOBILE_MENU_TEMPLATE)[0];
         this.mobileMenuScope = this.mapApi.$compile(mobileMenuTemplate);
@@ -114,10 +123,7 @@ export class PanelManager {
     }
 
     close() {
-        this.panel.element[0].removeEventListener('focus', (e: any) => scrollIntoView(e, this.panel.element[0]), true);
-        this.gridBody.removeEventListener('focus', (e: any) => tabToGrid(e, this.tableOptions, this.lastFilter), false);
         this.panel.close();
-        this.currentTableLayer = undefined;
     }
 
     onBtnExport() {
@@ -321,7 +327,7 @@ export class PanelManager {
             this.columnVisibilities = this.columns
                 .filter(element => element.headerName)
                 .map(element => {
-                    return ({ id: element.field, title: element.headerName, visibility: element.visibility })
+                    return ({ id: element.field, title: element.headerName, visibility: !element.hide })
                 });
 
             // toggle column visibility
@@ -365,7 +371,7 @@ export interface PanelManager {
     gridBody: HTMLElement;
     configManager: any;
     mobileMenuScope: MobileMenuScope;
-    recordCountScope: RecordCountScope
+    recordCountScope: RecordCountScope;
     panelStateManager: PanelStateManager;
     searchText: string;
 }


### PR DESCRIPTION
Make sure panel close deregisters table listeners

## Link to issue number(s):
https://github.com/fgpv-vpgf/fgpv-vpgf/issues/3235

## Summary of the issue:
Figure out what to do to an open table when its layer is reloaded. 

Also in this PR but without an issue is that the panel close button wouldn't destroy the table completely.

## Description of how this pull request fixes the issue:
Close an open table if its layer is reloaded. 

Enhance the panel's close button so it handles the table destruction properly. 

## Testing:
https://dane-thomas.github.io/plugins/327d369c718ba0bd01efc1666467b415e97fe985/enhancedTable/samples/et-index.html
-   [x] Test specs are up-to-date & cover all changes/additions made by this PR.
-   [ ] `npm run test` passes locally.

<!-- Comment if additional testing was performed or if test specs are not suited to cover all cases. Provide links to external resources where appropriate.  -->

## Documentation

-   [x] Documentation is up-to-date - any changes or additions have been noted
-   [ ] `changelog.md` has been updated

## Checklist

-   [x] PR has only one commit (squash otherwise)
-   [x] Commit message is descriptive
