### PR TITLE
fix(enhancedTable): fix extent filter not applied

### DIFF
--- a/enhancedTable/panel-manager.ts
+++ b/enhancedTable/panel-manager.ts
@@ -283,7 +283,7 @@ export class PanelManager {
             this.appID = that.mapApi.id;
             this.maximized = that.maximized ? 'true' : 'false';
             this.showFilter = !!that.tableOptions.floatingFilter;
-            this.filterByExtent = that.filterByExtent;
+            this.filterByExtent = that.panelStateManager.filterByExtent;
 
             // sets the table size, either split view or full height
             // saves the set size to PanelStateManager
@@ -312,8 +312,15 @@ export class PanelManager {
             };
 
             // Sync filterByExtent
-            this.setExtentFilter = function () {
-                that.filterByExtent = this.filterByExtent;
+            this.filterExtentToggled = function() {
+                that.panelStateManager.filterByExtent = this.filterByExtent;
+
+                // On toggle, filter by extent or remove the extent filter
+                if (that.panelStateManager.filterByExtent) {
+                    that.panelRowsManager.filterByExtent(that.mapApi.mapI.extent);
+                } else {
+                    that.panelRowsManager.fetchValidOids();
+                }
             };
         });
 

--- a/enhancedTable/panel-state-manager.ts
+++ b/enhancedTable/panel-state-manager.ts
@@ -13,6 +13,7 @@ export class PanelStateManager {
     constructor(baseLayer: any) {
         this.baseLayer = baseLayer;
         this.isMaximized = baseLayer.table.maximize || false;
+        this.filterByExtent = false;
         this.columnFilters = {};
     }
 
@@ -37,6 +38,7 @@ export class PanelStateManager {
 export interface PanelStateManager {
     baseLayer: any;
     isMaximized: boolean;
+    filterByExtent: boolean;
     rows: any;
     columnFilters: any;
 }

--- a/enhancedTable/templates.ts
+++ b/enhancedTable/templates.ts
@@ -80,7 +80,7 @@ export const MENU_TEMPLATE = (printEnabled: boolean) => {
                 {{ 't.menu.max' | translate }}
             </md-menu-item>
             <md-menu-divider class="rv-lg"></md-menu-divider>
-            <md-menu-item type="checkbox" ng-model="ctrl.filterByExtent" ng-click="ctrl.setExtentFilter()" rv-right-icon="community:filter">
+            <md-menu-item type="checkbox" ng-model="ctrl.filterByExtent" ng-click="ctrl.filterExtentToggled()" rv-right-icon="community:filter">
                 {{ 't.menu.filter.extent' | translate }}
             </md-menu-item>
             <md-menu-item type="checkbox" ng-model="ctrl.showFilter" ng-click="ctrl.toggleFilters()" rv-right-icon="community:filter">


### PR DESCRIPTION
## Link to issue number(s):
https://github.com/fgpv-vpgf/fgpv-vpgf/issues/3267

## Summary of the issue:
Extent filter not applied to/removed from the table on enable/disable. 
Extent filter not applied on table open when previously enabled.
Filter by extent stays enabled between tables.

## Description of how this pull request fixes the issue:
Triggers extent filter on enable and removes it on disable.
Applies extent filter on open if enabled.
Store extent filter enabled flag on state so it's preserved between table opens.

## Testing:
https://dane-thomas.github.io/plugins/df6721a912f43dbf7afba64ccba2d2956c67b0ad/enhancedTable/samples/et-index.html
-   ~~[ ] Test specs are up-to-date & cover all changes/additions made by this PR.~~
-   ~~[ ] `npm run test` passes locally.~~

<!-- Comment if additional testing was performed or if test specs are not suited to cover all cases. Provide links to external resources where appropriate.  -->

## Documentation

-   [x] Documentation is up-to-date - any changes or additions have been noted
-   [ ] `changelog.md` has been updated

## Checklist

-   [x] PR has only one commit (squash otherwise)
-   [x] Commit message is descriptive
