### PR TITLE
fix(enhancedTable): sort arrow indicator on first column

### DIFF
--- a/enhancedTable/panel-manager.ts
+++ b/enhancedTable/panel-manager.ts
@@ -107,7 +107,7 @@ export class PanelManager {
                 this.autoSizeToMaxWidth();
                 this.sizeColumnsToFitIfNeeded();
                 let colApi = this.tableOptions.columnApi
-                let col = colApi.getDisplayedColAfter(colApi.getColumn('rvInteractive'));
+                let col = colApi.getDisplayedColAfter(colApi.getColumn('zoom'));
                 if (col !== (undefined || null) && col.sort === undefined) {
                     // set sort of first column to ascending by default if sort isn't specified
                     col.setSort("asc");
@@ -316,7 +316,7 @@ export class PanelManager {
             };
 
             // Sync filterByExtent
-            this.filterExtentToggled = function() {
+            this.filterExtentToggled = function () {
                 that.panelStateManager.filterByExtent = this.filterByExtent;
 
                 // On toggle, filter by extent or remove the extent filter

--- a/lib/enhancedTable/panel-manager.js
+++ b/lib/enhancedTable/panel-manager.js
@@ -98,7 +98,7 @@ var PanelManager = /** @class */ (function () {
                 _this.autoSizeToMaxWidth();
                 _this.sizeColumnsToFitIfNeeded();
                 var colApi = _this.tableOptions.columnApi;
-                var col = colApi.getDisplayedColAfter(colApi.getColumn('rvInteractive'));
+                var col = colApi.getDisplayedColAfter(colApi.getColumn('zoom'));
                 if (col !== (undefined || null) && col.sort === undefined) {
                     // set sort of first column to ascending by default if sort isn't specified
                     col.setSort("asc");


### PR DESCRIPTION
## Link to issue number(s):
Closes https://github.com/fgpv-vpgf/fgpv-vpgf/issues/3306

## Summary of the issue:
Left most column did not have a visible sort indicator so it wasn't obvious that you could sort columns. Now it does. 

Test: http://fgpv.cloudapp.net/demo/users/ShrutiVellanki/update-wfs-import/dev/samples/index-samples.html

## Description of how this pull request fixes the issue:

## Testing:

-   ~[ ] Test specs are up-to-date & cover all changes/additions made by this PR.~
-   ~[ ] `npm run test` passes locally.~

<!-- Comment if additional testing was performed or if test specs are not suited to cover all cases. Provide links to external resources where appropriate.  -->

## Documentation

-   ~[ ] Documentation is up-to-date - any changes or additions have been noted~
-   ~[ ] `changelog.md` has been updated~

## Checklist

-   [x] PR has only one commit (squash otherwise)
-   [x] Commit message is descriptive
