### PR TITLE
fix(enhancedTable): fix menu close on keyboard up arrow press

### DIFF
--- a/enhancedTable/templates.ts
+++ b/enhancedTable/templates.ts
@@ -51,9 +51,9 @@ export const COLUMN_VISIBILITY_MENU_TEMPLATE = `
             <md-tooltip>{{ 't.table.hideColumns' | translate }}</md-tooltip>
             <md-icon md-svg-src="community:format-list-checks"></md-icon>
         </md-button>
-        <md-menu-content rv-trap-focus="{{::ctrl.appID}}" class="rv-menu rv-dense">
+        <md-menu-content class="rv-menu rv-dense">
             <md-menu-item ng-repeat="col in ctrl.columnVisibilities">
-                <md-button ng-click="ctrl.toggleColumn(col)" aria-label="{{ col.title }} " md-prevent-menu-close="md-prevent-menu-close">
+                <md-button ng-click="ctrl.toggleColumn(col)" aria-label="{{ col.title }}" md-prevent-menu-close="md-prevent-menu-close">
                     <span style='overflow-wrap:normal'>{{col.title}}</span>
                     <md-icon md-svg-icon="action:done" ng-if="col.visibility"></md-icon>
                 </md-button>
@@ -72,7 +72,7 @@ export const MENU_TEMPLATE = `
             ng-click="$mdOpenMenu($event)">
             <md-icon md-svg-src="navigation:more_vert"></md-icon>
         </md-button>
-        <md-menu-content rv-trap-focus="{{::ctrl.appID}}" class="rv-menu rv-dense">
+        <md-menu-content class="rv-menu rv-dense">
             <md-menu-item type="radio" ng-model="ctrl.maximized" value="false" ng-click="ctrl.setSize(ctrl.maximized)" ng-if="!sizeDisabled" rv-right-icon="none">
                 {{ 't.menu.split' | translate }}
             </md-menu-item>


### PR DESCRIPTION
## Link to issue number(s):
Closes https://github.com/fgpv-vpgf/fgpv-vpgf/issues/3342

## Summary of the issue:
Pressing the up arrow key to navigate the menu closes it

## Description of how this pull request fixes the issue:
Removes focus manager code that was on the menu. It was ca using the strange behavior 

## Testing:
[Test Link](https://dane-thomas.github.io/plugins/65804ff28f19ea7531883cf50c03fc4867bbb7bc/enhancedTable/samples/et-index.html)
-   [ ] Test specs are up-to-date & cover all changes/additions made by this PR.
-   [ ] `npm run test` passes locally.

<!-- Comment if additional testing was performed or if test specs are not suited to cover all cases. Provide links to external resources where appropriate.  -->

## Documentation

-   [ ] Documentation is up-to-date - any changes or additions have been noted
-   [ ] `changelog.md` has been updated

## Checklist

-   [x] PR has only one commit (squash otherwise)
-   [x] Commit message is descriptive

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/plugins/57)
<!-- Reviewable:end -->
