### PR TITLE
fix(enhancedTable): table opens for nested dynamic layers

### DIFF
--- a/enhancedTable/config-manager.ts
+++ b/enhancedTable/config-manager.ts
@@ -13,15 +13,7 @@ export class ConfigManager {
         this.attributeHeaders = baseLayer.attributeHeaders;
         this.attributeArray = baseLayer._attributeArray;
         this.columnConfigs = {};
-
-        if (baseLayer.layerIndex) {
-            // if baseLayer is a dynamic layer, table config corresponds to the one on layerEntry not baseLayer
-            let layer = baseLayer._mapInstance.layers.find(layer => layer.id === baseLayer.id);
-            let layerEntry = layer.layerEntries.find(entry => entry.index === baseLayer.layerIndex);
-            this.tableConfig = (layerEntry.table !== undefined) ? layerEntry.table : baseLayer.table;
-        } else {
-            this.tableConfig = baseLayer.table;
-        }
+        this.tableConfig = baseLayer.table;
         this.searchEnabled = this.tableConfig.search && this.tableConfig.search.enabled;
         this.tableInit();
     }

--- a/enhancedTable/index.ts
+++ b/enhancedTable/index.ts
@@ -40,6 +40,7 @@ export default class TableBuilder {
                 }
                 if (layer) {
                     this.legendBlock = legendBlock;
+                    this.panel.setLegendBlock(legendBlock);
                     this.openTable(layer);
                 }
             }

--- a/enhancedTable/panel-manager.ts
+++ b/enhancedTable/panel-manager.ts
@@ -45,17 +45,10 @@ export class PanelManager {
         this.panel.panelControls.after(mobileMenuTemplate);
     }
 
-    // recursively find and set the legend block for the layer
-    setLegendBlock(legendEntriesList: any) {
-        legendEntriesList.forEach(entry => {
-            if (entry.proxyWrapper !== undefined && this.currentTableLayer._layerProxy === entry.proxyWrapper.proxy) {
-                this.legendBlock = entry;
-            }
-            else if (entry.children || entry.entries) {
-                this.setLegendBlock(entry.children || entry.entries);
-            }
-        });
+    setLegendBlock(block) {
+        this.legendBlock = block;
     }
+
 
     open(tableOptions: any, layer: any) {
         if (this.currentTableLayer === layer) {
@@ -77,7 +70,6 @@ export class PanelManager {
 
             // set legend block / layer that the panel corresponds to
             this.currentTableLayer = layer;
-            this.setLegendBlock(this.currentTableLayer._mapInstance.legendBlocks.entries);
             this.panelRowsManager = new PanelRowsManager(this);
             // set header / controls for panel
             let controls = this.header;

--- a/lib/enhancedTable/config-manager.js
+++ b/lib/enhancedTable/config-manager.js
@@ -13,15 +13,7 @@ var ConfigManager = /** @class */ (function () {
         this.attributeHeaders = baseLayer.attributeHeaders;
         this.attributeArray = baseLayer._attributeArray;
         this.columnConfigs = {};
-        if (baseLayer.layerIndex) {
-            // if baseLayer is a dynamic layer, table config corresponds to the one on layerEntry not baseLayer
-            var layer = baseLayer._mapInstance.layers.find(function (layer) { return layer.id === baseLayer.id; });
-            var layerEntry = layer.layerEntries.find(function (entry) { return entry.index === baseLayer.layerIndex; });
-            this.tableConfig = (layerEntry.table !== undefined) ? layerEntry.table : baseLayer.table;
-        }
-        else {
-            this.tableConfig = baseLayer.table;
-        }
+        this.tableConfig = baseLayer.table;
         this.searchEnabled = this.tableConfig.search && this.tableConfig.search.enabled;
         this.tableInit();
     }


### PR DESCRIPTION
## Link to issue number(s):
https://github.com/fgpv-vpgf/fgpv-vpgf/issues/3373

## Summary of the issue:
Layer wouldn't open for dynamic layers and for some layers whose proxys were slow to resolve. 

## Description of how this pull request fixes the issue:

- Removes redundant recursion search for `legendBlock` and just uses `legendBlock` from `index.ts` (fixes sample 75 issue)
- Removes redundant check from `config-manager.ts`, same check is on line 36 of `index.ts`

## Testing:
you can test using the `table-open` branch I pushed to my viewer repo here: http://fgpv.cloudapp.net/demo/users/ShrutiVellanki/table-open/dev/samples/index-samples.html
- makes testing the samples easier
- make sure my deletions didn't break something that was working before this PR

-   [ ] Test specs are up-to-date & cover all changes/additions made by this PR.
-   [ ] `npm run test` passes locally.

<!-- Comment if additional testing was performed or if test specs are not suited to cover all cases. Provide links to external resources where appropriate.  -->

## Documentation
n/a
-   [ ] Documentation is up-to-date - any changes or additions have been noted
-   [ ] `changelog.md` has been updated

## Checklist

-   [x] PR has only one commit (squash otherwise)
-   [x] Commit message is descriptive

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/plugins/64)
<!-- Reviewable:end -->
