### PR TITLE
fix(enhancedTable): keep column state on subsequent loads

### DIFF
--- a/enhancedTable/index.ts
+++ b/enhancedTable/index.ts
@@ -20,7 +20,7 @@ export default class TableBuilder {
         this.mapApi = mapApi;
 
         this.panel = new PanelManager(mapApi);
-        this.panel.reload = this.reloadTable.bind(this)
+        this.panel.reload = this.reloadTable.bind(this);
 
         this.mapApi.layers.reload.subscribe((baseLayer: any, interval: boolean) => {
             if (!interval && baseLayer === this.panel.currentTableLayer) {
@@ -34,9 +34,11 @@ export default class TableBuilder {
                 // switch state of whether the table is open or not
                 this.panel.panelStateManager.isOpen = !this.panel.panelStateManager.isOpen;
             }
-            if (this.panel.panelStateManager === undefined ||
+            if (
+                this.panel.panelStateManager === undefined ||
                 this.panel.panelStateManager.isOpen === true ||
-                legendBlock !== this.panel.panelStateManager.legendBlock) {
+                legendBlock !== this.panel.panelStateManager.legendBlock
+            ) {
                 // if table has never been created, was closed until now, or you are opening a different table
                 // go through loading + opening steps
                 if (this.panel.panelStateManager !== undefined && legendBlock !== this.panel.panelStateManager.legendBlock) {
@@ -63,21 +65,20 @@ export default class TableBuilder {
             // make sure the item clicked is a node, and not group or other
             let layer;
             if (legendBlock.parentLayerType === 'esriDynamic') {
-                layer = this.mapApi.layers.allLayers.find(function (l) {
+                layer = this.mapApi.layers.allLayers.find(function(l) {
                     return l.id === legendBlock.layerRecordId && l.layerIndex === parseInt(legendBlock.itemIndex);
                 });
             } else {
                 layer = this.mapApi.layers.getLayersById(legendBlock.layerRecordId)[0];
             }
 
-
             if (layer) {
                 // if layer was created unsubscribe to layer added observable
                 // create + open the enhancedTable
                 this.legendBlock = legendBlock;
-                this.panel.setLegendBlock(legendBlock)
+                this.panel.setLegendBlock(legendBlock);
                 if (this.layerAdded !== undefined) {
-                    this.layerAdded.unsubscribe()
+                    this.layerAdded.unsubscribe();
                 }
                 this.loadingPanel.setSize(layer.table.maximize); //make sure loading panel is maximized/minimized according to config
                 this.openTable(layer);
@@ -94,7 +95,6 @@ export default class TableBuilder {
     }
 
     openTable(baseLayer) {
-
         if (baseLayer.panelStateManager === undefined) {
             // if no PanelStateManager exists for this BaseLayer, create a new one
             baseLayer.panelStateManager = new PanelStateManager(baseLayer, this.legendBlock);
@@ -106,13 +106,12 @@ export default class TableBuilder {
         if (attrs.length === 0) {
             // make sure all attributes are added before creating the table (otherwise table displays without SVGs)
             this.mapApi.layers.attributesAdded.pipe(take(1)).subscribe(attrs => {
-
                 if (attrs.attributes.length > 0) {
                     this.configManager = new ConfigManager(baseLayer, this.panel);
                     this.panel.configManager = this.configManager;
                     this.createTable(attrs);
                 } else {
-                    this.openTable(baseLayer)
+                    this.openTable(baseLayer);
                 }
             });
         } else {
@@ -134,7 +133,6 @@ export default class TableBuilder {
             $('#enhancedTableLoader').remove();
         }
     }
-
 
     createTable(attrBundle: AttrBundle) {
         let cols: Array<any> = [];
@@ -171,12 +169,16 @@ export default class TableBuilder {
                         suppressSorting: false,
                         suppressFilter: column.searchDisabled,
                         sort: column.sort,
-                        hide: this.configManager.filteredAttributes.length === 0 || column.value !== undefined ? false : column.column ? !column.column.visible : undefined
+                        hide:
+                            this.configManager.filteredAttributes.length === 0 || column.value !== undefined
+                                ? false
+                                : column.column
+                                ? !column.column.visible
+                                : undefined
                     };
 
-                    this.panel.notVisible[colDef.field] = this.configManager.filteredAttributes.length === 0 ?
-                        false : column.column ?
-                            !column.column.visible : undefined;
+                    this.panel.notVisible[colDef.field] =
+                        this.configManager.filteredAttributes.length === 0 ? false : column.column ? !column.column.visible : undefined;
 
                     // set up floating filters and column header
                     const fieldInfo = a.fields.find(field => field.name === columnName);
@@ -258,10 +260,10 @@ function setUpSymbolsAndInteractive(columnName: string, colDef: any, cols: any, 
         if (columnName === 'rvSymbol') {
             colDef.maxWidth = 82;
             // set svg symbol for the symbol column
-            colDef.cellRenderer = function (cell) {
+            colDef.cellRenderer = function(cell) {
                 return cell.value;
             };
-            colDef.cellStyle = function (cell) {
+            colDef.cellStyle = function(cell) {
                 return {
                     paddingTop: '7px'
                 };
@@ -271,10 +273,10 @@ function setUpSymbolsAndInteractive(columnName: string, colDef: any, cols: any, 
             // sets details and zoom buttons for the row
             let zoomDef = (<any>Object).assign({}, colDef);
             zoomDef.field = 'zoom';
-            zoomDef.cellRenderer = function (params) {
+            zoomDef.cellRenderer = function(params) {
                 var eSpan = $(ZOOM_TEMPLATE(params.data[layerProxy.oidField]));
                 mapApi.$compile(eSpan);
-                params.eGridCell.addEventListener('keydown', function (e) {
+                params.eGridCell.addEventListener('keydown', function(e) {
                     if (e.key === 'Enter') {
                         eSpan.click();
                     }
@@ -283,10 +285,10 @@ function setUpSymbolsAndInteractive(columnName: string, colDef: any, cols: any, 
                 return eSpan[0];
             };
             cols.splice(0, 0, zoomDef);
-            colDef.cellRenderer = function (params) {
+            colDef.cellRenderer = function(params) {
                 var eSpan = $(DETAILS_TEMPLATE(params.data[layerProxy.oidField]));
                 mapApi.$compile(eSpan);
-                params.eGridCell.addEventListener('keydown', function (e) {
+                params.eGridCell.addEventListener('keydown', function(e) {
                     if (e.key === 'Enter') {
                         eSpan.click();
                     }
@@ -337,7 +339,7 @@ interface ColumnDefinition {
     maxWidth?: number;
     width?: number;
     field: string;
-    headerComponent?: { new(): CustomHeader };
+    headerComponent?: { new (): CustomHeader };
     headerComponentParams?: HeaderComponentParams;
     filter: string;
     filterParams?: any;

--- a/enhancedTable/panel-manager.ts
+++ b/enhancedTable/panel-manager.ts
@@ -1,12 +1,23 @@
 import { Grid } from 'ag-grid-community';
-import { SEARCH_TEMPLATE, MENU_TEMPLATE, CLEAR_FILTERS_TEMPLATE, COLUMN_VISIBILITY_MENU_TEMPLATE, MOBILE_MENU_TEMPLATE, MOBILE_MENU_BTN_TEMPLATE, RECORD_COUNT_TEMPLATE, APPLY_TO_MAP_TEMPLATE, TABLE_UPDATE_TEMPLATE } from './templates';
+import {
+    SEARCH_TEMPLATE,
+    MENU_TEMPLATE,
+    CLEAR_FILTERS_TEMPLATE,
+    COLUMN_VISIBILITY_MENU_TEMPLATE,
+    MOBILE_MENU_TEMPLATE,
+    MOBILE_MENU_BTN_TEMPLATE,
+    RECORD_COUNT_TEMPLATE,
+    APPLY_TO_MAP_TEMPLATE,
+    TABLE_UPDATE_TEMPLATE
+} from './templates';
 import { DetailsAndZoomButtons } from './details-and-zoom-buttons';
 import { PanelRowsManager } from './panel-rows-manager';
 import { PanelStatusManager } from './panel-status-manager';
 import { removeAccessibilityListeners, initAccessibilityListeners } from './grid-accessibility';
 import { ColumnConfigManager } from './config-manager';
 import { PanelStateManager } from './panel-state-manager';
-import { PRINT_TABLE } from './templates'
+import { PRINT_TABLE } from './templates';
+import { ColumnState } from 'ag-grid-community/dist/lib/columnController/columnController';
 
 /**
  * Creates and manages one api panel instance to display the table in the ramp viewer. One panelManager is created for each map instance on the page.
@@ -14,9 +25,8 @@ import { PRINT_TABLE } from './templates'
  * This class also contains custom angular controllers to enable searching, printing, exporting, and more from angular material panel controls.
  */
 export class PanelManager {
-
     constructor(mapApi: any) {
-        this.notVisible = {}
+        this.notVisible = {};
         this.mapApi = mapApi;
         this.panel = this.mapApi.panels.create('enhancedTable');
         this.panel.body = $(`<div rv-focus-exempt></div>`);
@@ -46,6 +56,18 @@ export class PanelManager {
         });
     }
 
+    set panelStateManager(newPanelStateManager: PanelStateManager) {
+        // store the column state before replacing the state manager
+        if (this._panelStateManager) {
+            this._panelStateManager.columnState = this.tableOptions.columnApi.getColumnState();
+        }
+        this._panelStateManager = newPanelStateManager;
+    }
+
+    get panelStateManager() {
+        return this._panelStateManager;
+    }
+
     setLegendBlock(block) {
         this.legendBlock = block;
     }
@@ -61,10 +83,10 @@ export class PanelManager {
             this.tableOptions = tableOptions;
 
             // set filter change flag to true
-            this.tableOptions.onFilterChanged = (event) => {
+            this.tableOptions.onFilterChanged = event => {
                 this.sizeColumnsToFitIfNeeded();
                 this.filtersChanged = true;
-            }
+            };
 
             this.panelStatusManager = new PanelStatusManager(this);
             this.panelStatusManager.setFilterAndScrollWatch();
@@ -92,7 +114,11 @@ export class PanelManager {
             this.panel.body.empty();
             new Grid(this.panel.body[0], tableOptions);
             this.configManager.setDefaultGlobalSearchFilter();
-
+            // if theres stored column state give it to the table
+            if (this.panelStateManager.columnState) {
+                this.tableOptions.columnApi.setColumnState(this.panelStateManager.columnState);
+            }
+            this.panel.open();
             this.panelStatusManager.getScrollRange();
             this.panelRowsManager.initObservers();
 
@@ -100,17 +126,24 @@ export class PanelManager {
             this.panel.body.prepend(mobileMenuTemplate);
 
             this.tableOptions.onGridReady = () => {
-                let colApi = this.tableOptions.columnApi
+                // sync column state to visibility list
+                this.updateColumnVisibility();
+                this.autoSizeToMaxWidth();
+                this.sizeColumnsToFitIfNeeded();
+                let colApi = this.tableOptions.columnApi;
                 let col = colApi.getDisplayedColAfter(colApi.getColumn('zoom'));
                 if (col !== (undefined || null) && col.sort === undefined) {
                     // set sort of first column to ascending by default if sort isn't specified
-                    col.setSort("asc");
+                    col.setSort('asc');
                 }
 
                 // Set up grid panel accessibility
                 // Link clicked legend element to the opened table
-                const sourceEl = $(document).find(`[legend-block-id="${this.legendBlock.id}"] button`).filter(':visible').first();
-                (<EnhancedJQuery><unknown>$(sourceEl)).link($(document).find(`#enhancedTable`));
+                const sourceEl = $(document)
+                    .find(`[legend-block-id="${this.legendBlock.id}"] button`)
+                    .filter(':visible')
+                    .first();
+                (<EnhancedJQuery>(<unknown>$(sourceEl))).link($(document).find(`#enhancedTable`));
 
                 // Set up grid <-> filter accessibility
                 this.gridBody = this.panel.element[0].getElementsByClassName('ag-body')[0];
@@ -143,8 +176,6 @@ export class PanelManager {
                 this.sizeColumnsToFitIfNeeded();
             };
         }
-
-
     }
 
     close() {
@@ -177,7 +208,6 @@ export class PanelManager {
         // create a printable HTML table with only rows and columns that
         // are currently displayed.
         return PRINT_TABLE(this.configManager.title, columns, rows);
-
     }
 
     setSize() {
@@ -208,7 +238,7 @@ export class PanelManager {
                 this.tableOptions.columnApi.setColumnWidth(c, maxWidth);
             }
         });
-    };
+    }
 
     /**
      * Check if columns don't take up entire grid width. If not size the columns to fit.
@@ -229,6 +259,18 @@ export class PanelManager {
         }
     }
 
+    /**
+     * Updates the column visibility list used for the columnVisibility control
+     */
+    updateColumnVisibility(): void {
+        const columnStates: ColumnState[] = this.tableOptions.columnApi.getColumnState();
+        this.columnMenuCtrl.columnVisibilities.forEach(column => {
+            column.visibility = !columnStates.find(columnState => {
+                return column.id === columnState.colId;
+            }).hide;
+        });
+    }
+
     get id(): string {
         this._id = this._id ? this._id : 'fancyTablePanel-' + Math.floor(Math.random() * 1000000 + 1) + Date.now();
         return this._id;
@@ -241,7 +283,10 @@ export class PanelManager {
 
         // remove old controls
         header.controls.find('.table-control').remove();
-        header.controls.find('.mobile-table-control').not('.mobile-table-menu').remove();
+        header.controls
+            .find('.mobile-table-control')
+            .not('.mobile-table-menu')
+            .remove();
         // add table controls
         header.prepend(this.compileTemplate(MOBILE_MENU_BTN_TEMPLATE));
         header.prepend(this.compileTemplate(MENU_TEMPLATE));
@@ -258,8 +303,8 @@ export class PanelManager {
 
     angularHeader() {
         const that = this;
-        this.mapApi.agControllerRegister('ToastCtrl', function ($scope, $mdToast, $rootElement) {
-            that.showToast = function () {
+        this.mapApi.agControllerRegister('ToastCtrl', function($scope, $mdToast, $rootElement) {
+            that.showToast = function() {
                 if ($rootElement.find('.table-toast').length === 0) {
                     $mdToast.show({
                         template: TABLE_UPDATE_TEMPLATE,
@@ -279,10 +324,10 @@ export class PanelManager {
             $scope.closeToast = () => $mdToast.hide();
         });
 
-        this.mapApi.agControllerRegister('SearchCtrl', function () {
+        this.mapApi.agControllerRegister('SearchCtrl', function() {
             that.searchText = that.configManager.defaultGlobalSearch;
             this.searchText = that.searchText ? that.searchText : '';
-            this.updatedSearchText = function () {
+            this.updatedSearchText = function() {
                 that.searchText = this.searchText;
                 // don't filter unless there are at least 3 characters
                 if (this.searchText.length > 2) {
@@ -296,7 +341,7 @@ export class PanelManager {
                 that.panelStatusManager.getFilterStatus();
                 that.tableOptions.api.deselectAllFiltered();
             };
-            this.clearSearch = function () {
+            this.clearSearch = function() {
                 that.searchText = '';
                 this.searchText = that.searchText;
                 this.updatedSearchText();
@@ -306,7 +351,7 @@ export class PanelManager {
             that.clearGlobalSearch = this.clearSearch.bind(this);
         });
 
-        this.mapApi.agControllerRegister('MenuCtrl', function () {
+        this.mapApi.agControllerRegister('MenuCtrl', function() {
             this.appID = that.mapApi.id;
             this.maximized = that.maximized ? 'true' : 'false';
             this.showFilter = !!that.tableOptions.floatingFilter;
@@ -315,7 +360,7 @@ export class PanelManager {
 
             // sets the table size, either split view or full height
             // saves the set size to PanelStateManager
-            this.setSize = function (value) {
+            this.setSize = function(value) {
                 that.panelStateManager.maximized = value === 'true' ? true : false;
                 !that.maximized ? that.mapApi.mapI.externalPanel(undefined) : that.mapApi.mapI.externalPanel($('#enhancedTable'));
                 that.maximized = value === 'true' ? true : false;
@@ -324,23 +369,23 @@ export class PanelManager {
             };
 
             // print button has been clicked
-            this.print = function () {
+            this.print = function() {
                 that.onBtnPrint();
             };
 
             // export button has been clicked
-            this.export = function () {
+            this.export = function() {
                 that.onBtnExport();
             };
 
             // Hide filters button has been clicked
-            this.toggleFilters = function () {
+            this.toggleFilters = function() {
                 that.tableOptions.floatingFilter = this.showFilter;
                 that.tableOptions.api.refreshHeader();
             };
 
             // Sync filterByExtent
-            this.filterExtentToggled = function () {
+            this.filterExtentToggled = function() {
                 that.panelStateManager.filterByExtent = this.filterByExtent;
 
                 // On toggle, filter by extent or remove the extent filter
@@ -352,10 +397,9 @@ export class PanelManager {
             };
         });
 
-        this.mapApi.agControllerRegister('ClearFiltersCtrl', function () {
+        this.mapApi.agControllerRegister('ClearFiltersCtrl', function() {
             // clear all column filters
-            this.clearFilters = function () {
-
+            this.clearFilters = function() {
                 const columns = Object.keys(that.tableOptions.api.getFilterModel());
                 let newFilterModel = {};
 
@@ -378,11 +422,11 @@ export class PanelManager {
             // determine if there are any active column filters
             // returns true if there are no active column filters, false otherwise
             // this determines if Clear Filters button is disabled (when true) or enabled (when false)
-            this.noActiveFilters = function () {
+            this.noActiveFilters = function() {
                 if (that.tableOptions.api !== undefined) {
                     const columns = Object.keys(that.tableOptions.api.getFilterModel());
                     // if there is a non static column fiter, the clearFilters button is enabled
-                    let noFilters = !columns.some((col) => {
+                    let noFilters = !columns.some(col => {
                         const columnConfigManager = new ColumnConfigManager(that.configManager, col);
                         return !columnConfigManager.isFilterStatic;
                     });
@@ -391,17 +435,17 @@ export class PanelManager {
                 } else {
                     return true;
                 }
-            }
+            };
         });
 
-        this.mapApi.agControllerRegister('ApplyToMapCtrl', function () {
+        this.mapApi.agControllerRegister('ApplyToMapCtrl', function() {
             // returns true if a filter has been changed since the last
-            this.filtersChanged = function () {
+            this.filtersChanged = function() {
                 return that.filtersChanged;
             };
 
             // apply filters to map
-            this.applyToMap = function () {
+            this.applyToMap = function() {
                 const filter = that.legendBlock.proxyWrapper.filterState;
                 filter.setSql(filter.coreFilterTypes.GRID, getFiltersQuery());
                 that.filtersChanged = false;
@@ -416,7 +460,8 @@ export class PanelManager {
                 });
                 if (that.searchText) {
                     const globalSearchVal = globalSearchToSql();
-                    if (globalSearchVal) { // will be an empty string if there are no visible rows
+                    if (globalSearchVal) {
+                        // will be an empty string if there are no visible rows
                         colStrs.push(globalSearchVal);
                     }
                 }
@@ -435,7 +480,7 @@ export class PanelManager {
                             if (val !== '') {
                                 if (that.configManager.lazyFilterEnabled) {
                                     const filterVal = `*${val}`;
-                                    val = filterVal.split(" ").join("*");
+                                    val = filterVal.split(' ').join('*');
                                 }
                                 return `UPPER(${col}) LIKE \'${val.replace(/\*/g, '%').toUpperCase()}%\'`;
                             }
@@ -476,10 +521,20 @@ export class PanelManager {
             // convert global search to SQL string filter of columns excluding unfiltered columns
             function globalSearchToSql(): string {
                 let val = that.searchText.replace(/'/g, "''");
-                const filterVal = `%${val.replace(/\*/g, '%').split(" ").join("%").toUpperCase()}`;
-                const re = new RegExp(`.*${val.split(" ").join(".*").toUpperCase()}`);
+                const filterVal = `%${val
+                    .replace(/\*/g, '%')
+                    .split(' ')
+                    .join('%')
+                    .toUpperCase()}`;
+                const re = new RegExp(
+                    `.*${val
+                        .split(' ')
+                        .join('.*')
+                        .toUpperCase()}`
+                );
                 const sortedRows = that.tableOptions.api.rowModel.rowsToDisplay;
-                const columns = that.tableOptions.columnApi.getAllDisplayedColumns()
+                const columns = that.tableOptions.columnApi
+                    .getAllDisplayedColumns()
                     .filter(column => column.colDef.filter === 'agTextColumnFilter');
                 columns.splice(0, 3);
                 let filteredColumns = [];
@@ -494,21 +549,23 @@ export class PanelManager {
             }
         });
 
-        this.mapApi.agControllerRegister('ColumnVisibilityMenuCtrl', function () {
+        this.mapApi.agControllerRegister('ColumnVisibilityMenuCtrl', function() {
             that.columnMenuCtrl = this;
             this.columns = that.tableOptions.columnDefs;
             this.columnVisibilities = this.columns
                 .filter(element => element.headerName)
                 .map(element => {
-                    return ({ id: element.field, title: element.headerName, visibility: !element.hide });
+                    return { id: element.field, title: element.headerName, visibility: !element.hide };
                 })
                 .sort((firstEl, secondEl) => firstEl['title'].localeCompare(secondEl['title']));
 
             // toggle column visibility
-            this.toggleColumn = function (col) {
-                col.visibility = !col.visibility;
+            this.toggleColumn = function(col) {
+                const column = that.tableOptions.columnApi.getColumn(col.id);
 
-                that.tableOptions.columnApi.setColumnVisible(col.id, col.visibility);
+                col.visibility = !column.visible;
+
+                that.tableOptions.columnApi.setColumnVisible(col.id, !column.visible);
 
                 // on showing a column resize to autowidth then shrink columns that are too wide
                 if (col.visibility) {
@@ -520,11 +577,11 @@ export class PanelManager {
             };
         });
 
-        this.mapApi.agControllerRegister('MobileMenuCtrl', function () {
+        this.mapApi.agControllerRegister('MobileMenuCtrl', function() {
             that.mobileMenuScope.visible = false;
             that.mobileMenuScope.sizeDisabled = true;
 
-            this.toggleMenu = function () {
+            this.toggleMenu = function() {
                 that.mobileMenuScope.visible = !that.mobileMenuScope.visible;
             };
         });
@@ -532,7 +589,7 @@ export class PanelManager {
 
     compileTemplate(template): JQuery<HTMLElement> {
         let temp = $(template);
-        this.mapApi.$compile(temp)
+        this.mapApi.$compile(temp);
         return temp;
     }
 }
@@ -552,7 +609,7 @@ export interface PanelManager {
     configManager: any;
     mobileMenuScope: MobileMenuScope;
     recordCountScope: RecordCountScope;
-    panelStateManager: PanelStateManager;
+    _panelStateManager: PanelStateManager;
     searchText: string;
     filterByExtent: boolean;
     filtersChanged: boolean;

--- a/enhancedTable/panel-state-manager.ts
+++ b/enhancedTable/panel-state-manager.ts
@@ -1,5 +1,3 @@
-import { PanelManager } from './panel-manager';
-
 /**
  * Saves relevant enhancedTable states so that it can be reset on reload/reopen. A PanelStateManager is linked to a BaseLayer.
  * setters are called each time enhancedTable states are updated, getters are called each time enhancedTable is reloaded/reopened.
@@ -9,7 +7,6 @@ import { PanelManager } from './panel-manager';
  *      - whether table maximized is in maximized or split view
  */
 export class PanelStateManager {
-
     constructor(baseLayer: any, legendBlock: any) {
         this.baseLayer = baseLayer;
         this.isMaximized = baseLayer.table.maximize || false;
@@ -17,6 +14,7 @@ export class PanelStateManager {
         this.columnFilters = {};
         this.open = true;
         this.storedBlock = legendBlock;
+        this.columnState = null;
     }
 
     getColumnFilter(colDefField: any): any {
@@ -46,7 +44,6 @@ export class PanelStateManager {
     get legendBlock(): any {
         return this.storedBlock;
     }
-
 }
 
 export interface PanelStateManager {
@@ -57,4 +54,5 @@ export interface PanelStateManager {
     columnFilters: any;
     open: boolean;
     storedBlock: any;
+    columnState: any;
 }


### PR DESCRIPTION
## Link to issue number(s):

fgpv-vpgf/fgpv-vpgf#3337

## Summary of the issue:

Column visibility was being reset between loads.

## Description of how this pull request fixes the issue:

Stores the column state from ag-grid and reloads it when needed.

## Testing:

-   [ ] Test specs are up-to-date & cover all changes/additions made by this PR.
-   [ ] `npm run test` passes locally.

<!-- Comment if additional testing was performed or if test specs are not suited to cover all cases. Provide links to external resources where appropriate.  -->

## Documentation

-   [x] Documentation is up-to-date - any changes or additions have been noted
-   [ ] `changelog.md` has been updated

## Checklist

-   [x] PR has only one commit (squash otherwise)
-   [x] Commit message is descriptive

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/plugins/66)
<!-- Reviewable:end -->
