### PR TITLE
fix(enhancedTable):  detect OID fields accurately

### DIFF
--- a/enhancedTable/details-and-zoom-buttons.ts
+++ b/enhancedTable/details-and-zoom-buttons.ts
@@ -10,6 +10,7 @@ export class DetailsAndZoomButtons {
         this.mapApi = panelManager.mapApi;
         this.legendBlock = panelManager.legendBlock;
         this.currentTableLayer = panelManager.currentTableLayer;
+        this.oidField = panelManager.currentTableLayer._layerProxy.oidField;
         this.setDetailsAndZoomButtons();
     }
 
@@ -18,12 +19,11 @@ export class DetailsAndZoomButtons {
         const that = this;
         this.mapApi.agControllerRegister('DetailsAndZoomCtrl', function () {
             let proxy = that.legendBlock.proxyWrapper.proxy;
-
             // opens the details panel corresponding to the row where the details button is found
             this.openDetails = function (oid) {
                 let data = proxy.attribs.then(function (attribs) {
                     const attributes = attribs.features.find(attrib => {
-                        if (attrib.attributes.OBJECTID === oid) {
+                        if (attrib.attributes[that.oidField] === oid) {
                             return attrib.attributes;
                         }
                     }).attributes;
@@ -94,4 +94,5 @@ export interface DetailsAndZoomButtons {
     mapApi: any;
     legendBlock: any;
     currentTableLayer: any;
+    oidField: any;
 }

--- a/enhancedTable/index.ts
+++ b/enhancedTable/index.ts
@@ -138,7 +138,9 @@ export default class TableBuilder {
 
     createTable(attrBundle: AttrBundle) {
         let cols: Array<any> = [];
-        attrBundle.layer._layerProxy.formattedAttributes.then(a => {
+        const layerProxy = attrBundle.layer._layerProxy;
+
+        layerProxy.formattedAttributes.then(a => {
             Object.keys(a.rows[0]).forEach(columnName => {
                 if (
                     columnName === 'rvSymbol' ||
@@ -218,7 +220,7 @@ export default class TableBuilder {
                     }
 
                     // symbols and interactive columns are set up for every table
-                    setUpSymbolsAndInteractive(columnName, colDef, cols, this.mapApi);
+                    setUpSymbolsAndInteractive(columnName, colDef, cols, this.mapApi, layerProxy);
                 }
             });
             (<any>Object).assign(this.tableOptions, {
@@ -246,7 +248,7 @@ export default class TableBuilder {
 }
 
 /* Helper function to set up symbols and interactive columns*/
-function setUpSymbolsAndInteractive(columnName: string, colDef: any, cols: any, mapApi: any) {
+function setUpSymbolsAndInteractive(columnName: string, colDef: any, cols: any, mapApi: any, layerProxy: any) {
     if (columnName === 'rvSymbol' || columnName === 'rvInteractive') {
         // symbols and interactive columns don't have options for sort, filter and have default widths
         colDef.suppressSorting = true;
@@ -270,7 +272,7 @@ function setUpSymbolsAndInteractive(columnName: string, colDef: any, cols: any, 
             let zoomDef = (<any>Object).assign({}, colDef);
             zoomDef.field = 'zoom';
             zoomDef.cellRenderer = function (params) {
-                var eSpan = $(ZOOM_TEMPLATE(params.data.OBJECTID));
+                var eSpan = $(ZOOM_TEMPLATE(params.data[layerProxy.oidField]));
                 mapApi.$compile(eSpan);
                 params.eGridCell.addEventListener('keydown', function (e) {
                     if (e.key === 'Enter') {
@@ -282,7 +284,7 @@ function setUpSymbolsAndInteractive(columnName: string, colDef: any, cols: any, 
             };
             cols.splice(0, 0, zoomDef);
             colDef.cellRenderer = function (params) {
-                var eSpan = $(DETAILS_TEMPLATE(params.data.OBJECTID));
+                var eSpan = $(DETAILS_TEMPLATE(params.data[layerProxy.oidField]));
                 mapApi.$compile(eSpan);
                 params.eGridCell.addEventListener('keydown', function (e) {
                     if (e.key === 'Enter') {

--- a/lib/enhancedTable/config-manager.d.ts
+++ b/lib/enhancedTable/config-manager.d.ts
@@ -57,9 +57,9 @@ export declare class ConfigManager {
 export declare class ColumnConfigManager {
     constructor(configManager: ConfigManager, column: any);
     /**
-    * Initializes column width according to specifications in the config on table creation
-    * If table needs to be filled up, disregards this width (respects table fill) ..i.e this is the minwidth
-    */
+     * Initializes column width according to specifications in the config on table creation
+     * If table needs to be filled up, disregards this width (respects table fill) ..i.e this is the minwidth
+     */
     readonly width: any;
     /**
      * Initializes column sorts according to specifications in the config on table creation
@@ -78,9 +78,9 @@ export declare class ColumnConfigManager {
      */
     readonly isSelector: boolean;
     /**
-    * Returns whether filter is static
-    * Set up on table create
-    */
+     * Returns whether filter is static
+     * Set up on table create
+     */
     readonly isFilterStatic: boolean;
     /**
      * Returns the column filter value that is seen on tabl open.

--- a/lib/enhancedTable/config-manager.js
+++ b/lib/enhancedTable/config-manager.js
@@ -147,9 +147,9 @@ var ColumnConfigManager = /** @class */ (function () {
     }
     Object.defineProperty(ColumnConfigManager.prototype, "width", {
         /**
-        * Initializes column width according to specifications in the config on table creation
-        * If table needs to be filled up, disregards this width (respects table fill) ..i.e this is the minwidth
-        */
+         * Initializes column width according to specifications in the config on table creation
+         * If table needs to be filled up, disregards this width (respects table fill) ..i.e this is the minwidth
+         */
         get: function () {
             return (this.column !== undefined) ? this.column.width : undefined;
         },
@@ -199,9 +199,9 @@ var ColumnConfigManager = /** @class */ (function () {
     });
     Object.defineProperty(ColumnConfigManager.prototype, "isFilterStatic", {
         /**
-        * Returns whether filter is static
-        * Set up on table create
-        */
+         * Returns whether filter is static
+         * Set up on table create
+         */
         get: function () {
             if (!(this.column === undefined || this.column.filter === undefined || this.column.filter.static === undefined)) {
                 return this.column.filter.static;

--- a/lib/enhancedTable/custom-floating-filters.d.ts
+++ b/lib/enhancedTable/custom-floating-filters.d.ts
@@ -7,15 +7,15 @@ export declare function setUpTextFilter(colDef: any, isStatic: boolean, lazyFilt
 /**Sets up a selector floating filter accounting for static types and default values*/
 export declare function setUpSelectorFilter(colDef: any, isItStatic: boolean, defaultValue: any, gridOptions: any, mapApi: any, panelStateManager: any): void;
 /**
-* Floating filter component enhanced for Static Text Filters
-*/
+ * Floating filter component enhanced for Static Text Filters
+ */
 export declare class TextFloatingFilter {
     init(params: any): void;
     /**
-    * Helper function to init
-    * Determines if preloaded value exists.
-    * If so fills col filter from either panelStateManager or default value from config
-    */
+     * Helper function to init
+     * Determines if preloaded value exists.
+     * If so fills col filter from either panelStateManager or default value from config
+     */
     preLoadedValue(): void;
     /** Helper function to determine filter model */
     getModel(): any;
@@ -24,16 +24,16 @@ export declare class TextFloatingFilter {
     onParentModelChanged(parentModel: any): void;
 }
 /**
-* Floating filter component enhanced for number
-* Has separate min and max input boxes
-*/
+ * Floating filter component enhanced for number
+ * Has separate min and max input boxes
+ */
 export declare class NumberFloatingFilter {
     init(params: any): void;
     /**
-    * Helper function to init
-    * Determines if preloaded value exists.
-    * If so fills col filter from either panelStateManager or default value from config
-    */
+     * Helper function to init
+     * Determines if preloaded value exists.
+     * If so fills col filter from either panelStateManager or default value from config
+     */
     readonly preLoadedValue: any;
     /** Update filter nimimum */
     onMinInputBoxChanged(): void;
@@ -63,15 +63,15 @@ export declare class DateFloatingFilter {
     getGui(): HTMLElement;
 }
 /**
-* Floating filter component enhanced for Static Text Filters
-*/
+ * Floating filter component enhanced for Static Text Filters
+ */
 export declare class SelectorFloatingFilter {
     init(params: any): void;
     /**
-    * Helper function to init
-    * Determines if preloaded value exists.
-    * If so fills col filter from either panelStateManager or default value from config
-    */
+     * Helper function to init
+     * Determines if preloaded value exists.
+     * If so fills col filter from either panelStateManager or default value from config
+     */
     preLoadedValue(): void;
     /** Helper function to determine filter model */
     getModel(): any;

--- a/lib/enhancedTable/custom-floating-filters.js
+++ b/lib/enhancedTable/custom-floating-filters.js
@@ -153,8 +153,8 @@ function getDateString(value) {
     return date.toLocaleDateString('en-CA', options);
 }
 /**
-* Floating filter component enhanced for Static Text Filters
-*/
+ * Floating filter component enhanced for Static Text Filters
+ */
 var TextFloatingFilter = /** @class */ (function () {
     function TextFloatingFilter() {
     }
@@ -175,10 +175,10 @@ var TextFloatingFilter = /** @class */ (function () {
     };
     ;
     /**
-    * Helper function to init
-    * Determines if preloaded value exists.
-    * If so fills col filter from either panelStateManager or default value from config
-    */
+     * Helper function to init
+     * Determines if preloaded value exists.
+     * If so fills col filter from either panelStateManager or default value from config
+     */
     TextFloatingFilter.prototype.preLoadedValue = function () {
         var reloadedVal = this.params.panelStateManager.getColumnFilter(this.params.currColumn.field);
         if (reloadedVal !== undefined) {
@@ -213,9 +213,9 @@ var TextFloatingFilter = /** @class */ (function () {
 }());
 exports.TextFloatingFilter = TextFloatingFilter;
 /**
-* Floating filter component enhanced for number
-* Has separate min and max input boxes
-*/
+ * Floating filter component enhanced for number
+ * Has separate min and max input boxes
+ */
 var NumberFloatingFilter = /** @class */ (function () {
     function NumberFloatingFilter() {
     }
@@ -237,10 +237,10 @@ var NumberFloatingFilter = /** @class */ (function () {
     };
     Object.defineProperty(NumberFloatingFilter.prototype, "preLoadedValue", {
         /**
-        * Helper function to init
-        * Determines if preloaded value exists.
-        * If so fills col filter from either panelStateManager or default value from config
-        */
+         * Helper function to init
+         * Determines if preloaded value exists.
+         * If so fills col filter from either panelStateManager or default value from config
+         */
         get: function () {
             var reloadedMinVal = this.params.panelStateManager.getColumnFilter(this.params.currColumn.field + ' min');
             var reloadedMaxVal = this.params.panelStateManager.getColumnFilter(this.params.currColumn.field + ' max');
@@ -438,8 +438,8 @@ var DateFloatingFilter = /** @class */ (function () {
 }());
 exports.DateFloatingFilter = DateFloatingFilter;
 /**
-* Floating filter component enhanced for Static Text Filters
-*/
+ * Floating filter component enhanced for Static Text Filters
+ */
 var SelectorFloatingFilter = /** @class */ (function () {
     function SelectorFloatingFilter() {
     }
@@ -480,10 +480,10 @@ var SelectorFloatingFilter = /** @class */ (function () {
         });
     };
     /**
-    * Helper function to init
-    * Determines if preloaded value exists.
-    * If so fills col filter from either panelStateManager or default value from config
-    */
+     * Helper function to init
+     * Determines if preloaded value exists.
+     * If so fills col filter from either panelStateManager or default value from config
+     */
     SelectorFloatingFilter.prototype.preLoadedValue = function () {
         var reloadedVal = this.params.panelStateManager.getColumnFilter(this.params.currColumn.field) === null ? '' :
             this.params.panelStateManager.getColumnFilter(this.params.currColumn.field);

--- a/lib/enhancedTable/details-and-zoom-buttons.d.ts
+++ b/lib/enhancedTable/details-and-zoom-buttons.d.ts
@@ -12,4 +12,5 @@ export interface DetailsAndZoomButtons {
     mapApi: any;
     legendBlock: any;
     currentTableLayer: any;
+    oidField: any;
 }

--- a/lib/enhancedTable/details-and-zoom-buttons.js
+++ b/lib/enhancedTable/details-and-zoom-buttons.js
@@ -11,6 +11,7 @@ var DetailsAndZoomButtons = /** @class */ (function () {
         this.mapApi = panelManager.mapApi;
         this.legendBlock = panelManager.legendBlock;
         this.currentTableLayer = panelManager.currentTableLayer;
+        this.oidField = panelManager.currentTableLayer._layerProxy.oidField;
         this.setDetailsAndZoomButtons();
     }
     // registers the DetailsAndZoomCtrl
@@ -22,7 +23,7 @@ var DetailsAndZoomButtons = /** @class */ (function () {
             this.openDetails = function (oid) {
                 var data = proxy.attribs.then(function (attribs) {
                     var attributes = attribs.features.find(function (attrib) {
-                        if (attrib.attributes.OBJECTID === oid) {
+                        if (attrib.attributes[that.oidField] === oid) {
                             return attrib.attributes;
                         }
                     }).attributes;

--- a/lib/enhancedTable/index.js
+++ b/lib/enhancedTable/index.js
@@ -131,7 +131,8 @@ var TableBuilder = /** @class */ (function () {
     TableBuilder.prototype.createTable = function (attrBundle) {
         var _this = this;
         var cols = [];
-        attrBundle.layer._layerProxy.formattedAttributes.then(function (a) {
+        var layerProxy = attrBundle.layer._layerProxy;
+        layerProxy.formattedAttributes.then(function (a) {
             Object.keys(a.rows[0]).forEach(function (columnName) {
                 if (columnName === 'rvSymbol' ||
                     columnName === 'rvInteractive' ||
@@ -162,7 +163,7 @@ var TableBuilder = /** @class */ (function () {
                     };
                     _this.panel.notVisible[colDef.field] = _this.configManager.filteredAttributes.length === 0 ?
                         false : column.column ?
-                        !column.column.visible : undefined;
+                            !column.column.visible : undefined;
                     // set up floating filters and column header
                     var fieldInfo = a.fields.find(function (field) { return field.name === columnName; });
                     if (fieldInfo) {
@@ -190,7 +191,7 @@ var TableBuilder = /** @class */ (function () {
                         setUpHeaderComponent(colDef, _this.mapApi);
                     }
                     // symbols and interactive columns are set up for every table
-                    setUpSymbolsAndInteractive(columnName, colDef, cols, _this.mapApi);
+                    setUpSymbolsAndInteractive(columnName, colDef, cols, _this.mapApi, layerProxy);
                 }
             });
             Object.assign(_this.tableOptions, {
@@ -216,7 +217,7 @@ var TableBuilder = /** @class */ (function () {
 }());
 exports.default = TableBuilder;
 /* Helper function to set up symbols and interactive columns*/
-function setUpSymbolsAndInteractive(columnName, colDef, cols, mapApi) {
+function setUpSymbolsAndInteractive(columnName, colDef, cols, mapApi, layerProxy) {
     if (columnName === 'rvSymbol' || columnName === 'rvInteractive') {
         // symbols and interactive columns don't have options for sort, filter and have default widths
         colDef.suppressSorting = true;
@@ -240,7 +241,7 @@ function setUpSymbolsAndInteractive(columnName, colDef, cols, mapApi) {
             var zoomDef = Object.assign({}, colDef);
             zoomDef.field = 'zoom';
             zoomDef.cellRenderer = function (params) {
-                var eSpan = $(templates_1.ZOOM_TEMPLATE(params.data.OBJECTID));
+                var eSpan = $(templates_1.ZOOM_TEMPLATE(params.data[layerProxy.oidField]));
                 mapApi.$compile(eSpan);
                 params.eGridCell.addEventListener('keydown', function (e) {
                     if (e.key === 'Enter') {
@@ -252,7 +253,7 @@ function setUpSymbolsAndInteractive(columnName, colDef, cols, mapApi) {
             };
             cols.splice(0, 0, zoomDef);
             colDef.cellRenderer = function (params) {
-                var eSpan = $(templates_1.DETAILS_TEMPLATE(params.data.OBJECTID));
+                var eSpan = $(templates_1.DETAILS_TEMPLATE(params.data[layerProxy.oidField]));
                 mapApi.$compile(eSpan);
                 params.eGridCell.addEventListener('keydown', function (e) {
                     if (e.key === 'Enter') {

--- a/lib/enhancedTable/panel-manager.d.ts
+++ b/lib/enhancedTable/panel-manager.d.ts
@@ -20,7 +20,7 @@ export declare class PanelManager {
      * Auto size all columns but check the max width
      * Note: Need a custom function here since setting maxWidth prevents
      *       `sizeColumnsToFit()` from filling the entire panel width
-    */
+     */
     autoSizeToMaxWidth(columns?: Array<any>): void;
     /**
      * Check if columns don't take up entire grid width. If not size the columns to fit.

--- a/lib/enhancedTable/panel-manager.js
+++ b/lib/enhancedTable/panel-manager.js
@@ -172,7 +172,7 @@ var PanelManager = /** @class */ (function () {
      * Auto size all columns but check the max width
      * Note: Need a custom function here since setting maxWidth prevents
      *       `sizeColumnsToFit()` from filling the entire panel width
-    */
+     */
     PanelManager.prototype.autoSizeToMaxWidth = function (columns) {
         var _this = this;
         var maxWidth = 400;

--- a/lib/enhancedTable/panel-rows-manager.d.ts
+++ b/lib/enhancedTable/panel-rows-manager.d.ts
@@ -6,18 +6,18 @@
 export declare class PanelRowsManager {
     constructor(panelManager: any);
     /**
-    * Table is set up according to layer visibiltiy on open
-    * Observers are set up in case of change to layer visibility or symbol visibility
-    */
+     * Table is set up according to layer visibiltiy on open
+     * Observers are set up in case of change to layer visibility or symbol visibility
+     */
     initObservers(): void;
     /**
-    * Destroy observers when table is closed
-    */
+     * Destroy observers when table is closed
+     */
     destroyObservers(): void;
     /**
-    * Helper method to initTableRowVisibility
-    * Sets table filters based on table visibility on open
-    */
+     * Helper method to initTableRowVisibility
+     * Sets table filters based on table visibility on open
+     */
     initialFilterSettings(): void;
     /**
      * Helper method to initObservers
@@ -25,9 +25,9 @@ export declare class PanelRowsManager {
      */
     initTableRowVisibility(): void;
     /**
-    * Helper method to multiple methods
-    * Tricks ag-grid into updating filter status by selecting all filtered rows
-    */
+     * Helper method to multiple methods
+     * Tricks ag-grid into updating filter status by selecting all filtered rows
+     */
     updateGridFilters(): void;
     /** Filter by extent if enabled */
     filterByExtent(extent: any): void;

--- a/lib/enhancedTable/panel-rows-manager.js
+++ b/lib/enhancedTable/panel-rows-manager.js
@@ -12,9 +12,9 @@ var PanelRowsManager = /** @class */ (function () {
         this.mapApi = panelManager.mapApi;
     }
     /**
-    * Table is set up according to layer visibiltiy on open
-    * Observers are set up in case of change to layer visibility or symbol visibility
-    */
+     * Table is set up according to layer visibiltiy on open
+     * Observers are set up in case of change to layer visibility or symbol visibility
+     */
     PanelRowsManager.prototype.initObservers = function () {
         var _this = this;
         this.legendBlock = this.panelManager.legendBlock;
@@ -50,16 +50,16 @@ var PanelRowsManager = /** @class */ (function () {
         });
     };
     /**
-    * Destroy observers when table is closed
-    */
+     * Destroy observers when table is closed
+     */
     PanelRowsManager.prototype.destroyObservers = function () {
         this.layerVisibilityObserver.unsubscribe();
         this.mapFilterChangedObserver.unsubscribe();
     };
     /**
-    * Helper method to initTableRowVisibility
-    * Sets table filters based on table visibility on open
-    */
+     * Helper method to initTableRowVisibility
+     * Sets table filters based on table visibility on open
+     */
     PanelRowsManager.prototype.initialFilterSettings = function () {
         if (!this.currentTableLayer.visibility) {
             // if  layer is invisible, table needs to show zero entries
@@ -97,9 +97,9 @@ var PanelRowsManager = /** @class */ (function () {
         }
     };
     /**
-    * Helper method to multiple methods
-    * Tricks ag-grid into updating filter status by selecting all filtered rows
-    */
+     * Helper method to multiple methods
+     * Tricks ag-grid into updating filter status by selecting all filtered rows
+     */
     PanelRowsManager.prototype.updateGridFilters = function () {
         this.tableOptions.api.onFilterChanged();
     };


### PR DESCRIPTION
## Link to issue number(s):
- Closes: https://github.com/fgpv-vpgf/fgpv-vpgf/issues/3396
- updates build (so you only really have to look at `details-and-zoom-buttons.ts` and `index.ts`)

## Summary of the issue:
- Reason details and zoom was failing for `sample 2` was because `OBJECTID` was encoded as `ID` and the details/zoom buttons didn't know how to retrieve the oid and return proper details/properly zoom

## Description of how this pull request fixes the issue:
- Determines proper `OBJECTID` field from `_layerProxy` and retrieves corresponding data that way (i.e. doesn't hard code `OBJECTID` anymore)

## Testing:

Test if sample 2 details/zoom work. Double check using other samples as well (on viewer PR).


-   [ ] Test specs are up-to-date & cover all changes/additions made by this PR.
-   [ ] `npm run test` passes locally.

<!-- Comment if additional testing was performed or if test specs are not suited to cover all cases. Provide links to external resources where appropriate.  -->

## Documentation

-   [x] Documentation is up-to-date - any changes or additions have been noted
-   [ ] `changelog.md` has been updated

## Checklist

-   [x] PR has only one commit (squash otherwise)
-   [x] Commit message is descriptive

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/plugins/70)
<!-- Reviewable:end -->
