### PR TITLE
fix(enhancedTable): close table on layer remove

### DIFF
--- a/enhancedTable/index.ts
+++ b/enhancedTable/index.ts
@@ -28,6 +28,12 @@ export default class TableBuilder {
             }
         });
 
+        this.mapApi.layers.layerRemoved.subscribe((baseLayer: any) => {
+            if (baseLayer === this.panel.currentTableLayer) {
+                this.panel.close();
+            }
+        })
+
         // toggle the enhancedTable if toggleDataTable is called from Legend API
         this.mapApi.ui.configLegend.dataTableToggled.subscribe(legendBlock => {
             // Open the table if its closed, never been created or this is a different legend block

--- a/lib/enhancedTable/custom-header.js
+++ b/lib/enhancedTable/custom-header.js
@@ -55,6 +55,7 @@ var CustomHeader = /** @class */ (function () {
         this.moveRightButton.removeEventListener('touchstart', moveRightListener);
         this.agParams.column.removeEventListener('sortChanged', onSortChangedListener);
         this.agParams.column.removeEventListener('leftChanged', onColumnReorderListener);
+        this.agParams.tableOptions.api.removeEventListener("columnVisible", onColumnReorderListener);
     };
     /** Update sort indicator visibility */
     CustomHeader.prototype.onSortChanged = function () {

--- a/lib/enhancedTable/index.js
+++ b/lib/enhancedTable/index.js
@@ -25,6 +25,11 @@ var TableBuilder = /** @class */ (function () {
                 _this.reloadTable(baseLayer);
             }
         });
+        this.mapApi.layers.layerRemoved.subscribe(function (baseLayer) {
+            if (baseLayer === _this.panel.currentTableLayer) {
+                _this.panel.close();
+            }
+        });
         // toggle the enhancedTable if toggleDataTable is called from Legend API
         this.mapApi.ui.configLegend.dataTableToggled.subscribe(function (legendBlock) {
             // Open the table if its closed, never been created or this is a different legend block


### PR DESCRIPTION
## Link to issue number(s):
https://github.com/fgpv-vpgf/fgpv-vpgf/issues/3439
## Summary of the issue:
Table doesn't close on layer remove
## Description of how this pull request fixes the issue:
Adds an observer to close the table on layer removal

**NOTE: LIMITATIONS**
With these changes the table will close once the "undo remove" toast closes. 
Table will not close until all children are removed  for dynamic layers. 

## Testing:
https://dane-thomas.github.io/plugins/ff69e8c8d4fdb4633d7e3a4bb9e3d4d37b6a1bd4/enhancedTable/samples/et-index.html
-   [ ] Test specs are up-to-date & cover all changes/additions made by this PR.
-   [ ] `npm run test` passes locally.

<!-- Comment if additional testing was performed or if test specs are not suited to cover all cases. Provide links to external resources where appropriate.  -->

## Documentation

-   [ ] Documentation is up-to-date - any changes or additions have been noted
-   [ ] `changelog.md` has been updated

## Checklist

-   [x] PR has only one commit (squash otherwise)
-   [x] Commit message is descriptive

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/plugins/79)
<!-- Reviewable:end -->
