### PR TITLE
fix(enhancedTable): fix apply to map enable/disabling

### DIFF
--- a/enhancedTable/panel-manager.ts
+++ b/enhancedTable/panel-manager.ts
@@ -506,7 +506,9 @@ export class PanelManager {
                 });
 
                 newFilterModel = newFilterModel !== {} ? newFilterModel : null;
-                that.clearGlobalSearch();
+                if (that.clearGlobalSearch !== undefined) {
+                    that.clearGlobalSearch();
+                }
                 that.tableOptions.api.setFilterModel(newFilterModel);
             };
 
@@ -530,15 +532,25 @@ export class PanelManager {
         });
 
         this.mapApi.agControllerRegister('ApplyToMapCtrl', function () {
-            // returns true if a filter has been changed since the last
+
+            let mapFilterQuery = "";
+
             this.filtersChanged = function () {
-                return that.filtersChanged;
+                if (that.filtersChanged) {
+                    // if filter is changed
+                    // check if filter changed is the same as one applied to map
+                    // if not, apply to map will be enabled
+                    // else it will be disabled
+                    return getFiltersQuery() !== mapFilterQuery;
+                }
+                return false;
             };
 
             // apply filters to map
             this.applyToMap = function () {
                 const filter = that.legendBlock.proxyWrapper.filterState;
-                filter.setSql(filter.coreFilterTypes.GRID, getFiltersQuery());
+                mapFilterQuery = getFiltersQuery();
+                filter.setSql(filter.coreFilterTypes.GRID, mapFilterQuery);
                 that.filtersChanged = false;
             };
 

--- a/lib/enhancedTable/panel-manager.js
+++ b/lib/enhancedTable/panel-manager.js
@@ -450,7 +450,9 @@ var PanelManager = /** @class */ (function () {
                     }
                 });
                 newFilterModel = newFilterModel !== {} ? newFilterModel : null;
-                that.clearGlobalSearch();
+                if (that.clearGlobalSearch !== undefined) {
+                    that.clearGlobalSearch();
+                }
                 that.tableOptions.api.setFilterModel(newFilterModel);
             };
             // determine if there are any active column filters
@@ -473,14 +475,22 @@ var PanelManager = /** @class */ (function () {
             };
         });
         this.mapApi.agControllerRegister('ApplyToMapCtrl', function () {
-            // returns true if a filter has been changed since the last
+            var mapFilterQuery = "";
             this.filtersChanged = function () {
-                return that.filtersChanged;
+                if (that.filtersChanged) {
+                    // if filter is changed
+                    // check if filter changed is the same as one applied to map
+                    // if not, apply to map will be enabled
+                    // else it will be disabled
+                    return getFiltersQuery() !== mapFilterQuery;
+                }
+                return false;
             };
             // apply filters to map
             this.applyToMap = function () {
                 var filter = that.legendBlock.proxyWrapper.filterState;
-                filter.setSql(filter.coreFilterTypes.GRID, getFiltersQuery());
+                mapFilterQuery = getFiltersQuery();
+                filter.setSql(filter.coreFilterTypes.GRID, mapFilterQuery);
                 that.filtersChanged = false;
             };
             // get filter SQL qeury string


### PR DESCRIPTION
## Link to issue number(s):
https://github.com/fgpv-vpgf/fgpv-vpgf/issues/3450

## Summary of the issue:
When a filter is set on the table, NOT applied to map, and then cleared, the apply to map button is still enabled. 

## Description of how this pull request fixes the issue:
This PR checks if the changed filter is different from the one applied to map, and only then enables the apply to map button.


## [Testing](https://shrutivellanki.github.io/plugins/4df4fc7f42c8f09001997625ee8bae3a17c6c8a1/enhancedTable/samples/et-index.html):

^ test link takes a while to build with github pages

### Test Cases: 

#### Case 1: 
- set filter to table
- apply to map should be enabled,  DO NOT apply to map
- click clear filters
- apply to map should be disabled

#### Case 2: 
- set filter to table
- apply to map should be enabled, apply to map
- click clear filters
- apply to map should be enabled
- click apply to map, apply to map should be disabled

#### Case 3: 
- open layer with prexisting column filters
- do NOT apply to map
- clear filters
- apply to map should be disabled


-   [ ] Test specs are up-to-date & cover all changes/additions made by this PR.
-   [ ] `npm run test` passes locally.

<!-- Comment if additional testing was performed or if test specs are not suited to cover all cases. Provide links to external resources where appropriate.  -->

## Documentation
Inline comments

-   [x] Documentation is up-to-date - any changes or additions have been noted
-   [ ] `changelog.md` has been updated

## Checklist

-   [x] PR has only one commit (squash otherwise)
-   [x] Commit message is descriptive

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/plugins/85)
<!-- Reviewable:end -->
