### PR TITLE
fix(enhancedTable): add tablet-fullscreen mode to the datatable

### DIFF
--- a/enhancedTable/panel-manager.ts
+++ b/enhancedTable/panel-manager.ts
@@ -32,7 +32,7 @@ export class PanelManager {
         this.setListeners();
         this.prepListNavigation();
         this.panel.body = $(`<div rv-focus-exempt></div>`);
-        this.panel.element.addClass('ag-theme-material mobile-fullscreen');
+        this.panel.element.addClass('ag-theme-material mobile-fullscreen tablet-fullscreen');
         this.panel.element.css({
             top: '0px',
             left: '410px'

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@fgpv/rv-plugins",
-    "version": "3.0.0-6",
+    "version": "3.0.0-7",
     "description": "Plugins for the RAMP viewer supported by the core team.",
     "scripts": {
         "build": "webpack --config ./bin/build/webpack.config.js && npm run prepublishOnly",


### PR DESCRIPTION
## Link to issue number(s):
Closes https://github.com/fgpv-vpgf/fgpv-vpgf/issues/3466

## Summary of the issue:
Add a new `table-mode` panel class. It will fullscreen a panel when the screen is on the medium breakpoint between.

## Description of how this pull request fixes the issue:

## Testing:

-   [ ] Test specs are up-to-date & cover all changes/additions made by this PR.
-   [ ] `npm run test` passes locally.

<!-- Comment if additional testing was performed or if test specs are not suited to cover all cases. Provide links to external resources where appropriate.  -->

## Documentation

-   [ ] Documentation is up-to-date - any changes or additions have been noted
-   [ ] `changelog.md` has been updated

## Checklist

-   [x] PR has only one commit (squash otherwise)
-   [x] Commit message is descriptive

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/plugins/86)
<!-- Reviewable:end -->
