### PR TITLE
fix(enhancedTable): persistent tooltips removed

### DIFF
--- a/enhancedTable/panel-manager.ts
+++ b/enhancedTable/panel-manager.ts
@@ -392,6 +392,16 @@ export class PanelManager {
         this.mapApi.$compile($(`<div ng-controller="ToastCtrl as ctrl"></div>`));
     }
 
+    /**
+     * Forces tooltips to hide.
+     * Apply to map and clear filter tooltips are shown on click and mouseleave on IE/edge.
+     */
+    hideToolTips() {
+        Array.from(document.getElementsByTagName('md-tooltip')).forEach(tooltip => {
+            tooltip.classList.remove('md-show');
+        });
+    }
+
     angularHeader() {
         const that = this;
         this.mapApi.agControllerRegister('ToastCtrl', ['$scope', '$mdToast', '$rootElement', function ($scope, $mdToast, $rootElement) {
@@ -491,6 +501,7 @@ export class PanelManager {
         this.mapApi.agControllerRegister('ClearFiltersCtrl', function () {
             // clear all column filters
             this.clearFilters = function () {
+                that.hideToolTips();
                 const columns = Object.keys(that.tableOptions.api.getFilterModel());
                 let newFilterModel = {};
 
@@ -552,6 +563,7 @@ export class PanelManager {
                 mapFilterQuery = getFiltersQuery();
                 filter.setSql(filter.coreFilterTypes.GRID, mapFilterQuery);
                 that.filtersChanged = false;
+                that.hideToolTips();
             };
 
             // get filter SQL qeury string

--- a/lib/areasOfInterest/index.js
+++ b/lib/areasOfInterest/index.js
@@ -28,7 +28,7 @@ var AreasOfInterest = /** @class */ (function () {
         var _this = this;
         this.api = api;
         AreasOfInterest.instances[this.api.id] = this;
-        var topElement = $('<ul style="overflow-y:auto;" class="rv-list rv-basemap-list"></ul>');
+        var topElement = $('<ul class="rv-list rv-basemap-list"></ul>');
         this.config.areas.forEach(function (area, i) {
             var areaHTML = _this.config.noPicture ? html_assets_1.noPic : html_assets_1.hasPic;
             areaHTML = areaHTML.replace(/{areaIndex}/, i);

--- a/lib/enhancedTable/panel-manager.d.ts
+++ b/lib/enhancedTable/panel-manager.d.ts
@@ -42,6 +42,11 @@ export declare class PanelManager {
     updateColumnVisibility(): void;
     readonly id: string;
     makeHeader(): void;
+    /**
+     * Forces tooltips to hide.
+     * Apply to map and clear filter tooltips are shown on click and mouseleave on IE/edge.
+     */
+    hideToolTips(): void;
     angularHeader(): void;
     compileTemplate(template: any): JQuery<HTMLElement>;
 }

--- a/lib/enhancedTable/panel-manager.js
+++ b/lib/enhancedTable/panel-manager.js
@@ -22,7 +22,7 @@ var PanelManager = /** @class */ (function () {
         this.setListeners();
         this.prepListNavigation();
         this.panel.body = $("<div rv-focus-exempt></div>");
-        this.panel.element.addClass('ag-theme-material mobile-fullscreen');
+        this.panel.element.addClass('ag-theme-material mobile-fullscreen tablet-fullscreen');
         this.panel.element.css({
             top: '0px',
             left: '410px'
@@ -348,6 +348,15 @@ var PanelManager = /** @class */ (function () {
         }
         this.mapApi.$compile($("<div ng-controller=\"ToastCtrl as ctrl\"></div>"));
     };
+    /**
+     * Forces tooltips to hide.
+     * Apply to map and clear filter tooltips are shown on click and mouseleave on IE/edge.
+     */
+    PanelManager.prototype.hideToolTips = function () {
+        Array.from(document.getElementsByTagName('md-tooltip')).forEach(function (tooltip) {
+            tooltip.classList.remove('md-show');
+        });
+    };
     PanelManager.prototype.angularHeader = function () {
         var that = this;
         this.mapApi.agControllerRegister('ToastCtrl', ['$scope', '$mdToast', '$rootElement', function ($scope, $mdToast, $rootElement) {
@@ -437,6 +446,7 @@ var PanelManager = /** @class */ (function () {
         this.mapApi.agControllerRegister('ClearFiltersCtrl', function () {
             // clear all column filters
             this.clearFilters = function () {
+                that.hideToolTips();
                 var columns = Object.keys(that.tableOptions.api.getFilterModel());
                 var newFilterModel = {};
                 // go through the columns in the current filter model
@@ -492,6 +502,7 @@ var PanelManager = /** @class */ (function () {
                 mapFilterQuery = getFiltersQuery();
                 filter.setSql(filter.coreFilterTypes.GRID, mapFilterQuery);
                 that.filtersChanged = false;
+                that.hideToolTips();
             };
             // get filter SQL qeury string
             function getFiltersQuery() {


### PR DESCRIPTION
## Link to issue number(s):
Closes https://github.com/fgpv-vpgf/fgpv-vpgf/issues/3463

## Summary of the issue:
`Apply To Map` and `Clear Filters` tool tips persistent after click in IE and Edge. 

## Description of how this pull request fixes the issue:
- Tried for a long time to think of a more elegant way to do this, ended up forcing the remove of `md-show` class...seems to work.
- build update as usual `.js` files

## [Testing](https://shrutivellanki.github.io/plugins/b1e284b232ae4d51eaefed32b2ee679090def078/enhancedTable/samples/et-index.html):
Test in IE and Edge. Github pages takes a while to build test link

-   [ ] Test specs are up-to-date & cover all changes/additions made by this PR.
-   [ ] `npm run test` passes locally.

<!-- Comment if additional testing was performed or if test specs are not suited to cover all cases. Provide links to external resources where appropriate.  -->

## Documentation
inline comments
-   [x] Documentation is up-to-date - any changes or additions have been noted
-   [ ] `changelog.md` has been updated

## Checklist

-   [x] PR has only one commit (squash otherwise)
-   [x] Commit message is descriptive

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/plugins/88)
<!-- Reviewable:end -->
