### PR TITLE
3447 table closing correctly and 2547 api extent modifications

### DIFF
--- a/areasOfInterest/index.ts
+++ b/areasOfInterest/index.ts
@@ -38,7 +38,7 @@ class AreasOfInterest {
             topElement.append(areaHTML);
 
             const currBtn = topElement.find('button').last();
-            currBtn.click(() => (this.api.extent = area));
+            currBtn.click(() => (this.api.setExtent(area)));
         });
 
         this.button = this.api.mapI.addPluginButton(

--- a/enhancedTable/index.ts
+++ b/enhancedTable/index.ts
@@ -28,11 +28,11 @@ export default class TableBuilder {
             }
         });
 
-        this.mapApi.layers.layerRemoved.subscribe((baseLayer: any) => {
-            if (baseLayer === this.panelManager.currentTableLayer) {
+        this.mapApi.ui.configLegend.elementRemoved.subscribe(legendBlock => {
+            if (legendBlock === this.panelManager.panel.panelStateManager.legendBlock) {
                 this.panelManager.panel.close();
             }
-        })
+        });
 
         // toggle the enhancedTable if toggleDataTable is called from Legend API
         this.mapApi.ui.configLegend.dataTableToggled.subscribe(legendBlock => {

--- a/enhancedTable/index.ts
+++ b/enhancedTable/index.ts
@@ -29,7 +29,7 @@ export default class TableBuilder {
         });
 
         this.mapApi.ui.configLegend.elementRemoved.subscribe(legendBlock => {
-            if (legendBlock === this.panelManager.panel.panelStateManager.legendBlock) {
+            if (legendBlock === this.panelManager.legendBlock) {
                 this.panelManager.panel.close();
             }
         });

--- a/lib/areasOfInterest/index.js
+++ b/lib/areasOfInterest/index.js
@@ -35,7 +35,7 @@ var AreasOfInterest = /** @class */ (function () {
             areaHTML = areaHTML.replace(/{imgSrc}/, area.thumbnailUrl || html_assets_1.pinImg);
             topElement.append(areaHTML);
             var currBtn = topElement.find('button').last();
-            currBtn.click(function () { return (_this.api.extent = area); });
+            currBtn.click(function () { return (_this.api.setExtent(area)); });
         });
         this.button = this.api.mapI.addPluginButton(AreasOfInterest.prototype.translations[this._RV.getCurrentLang()].title, this.onMenuItemClick());
         this.makePanel(topElement);

--- a/lib/enhancedTable/index.d.ts
+++ b/lib/enhancedTable/index.d.ts
@@ -23,7 +23,7 @@ export default interface TableBuilder {
     mapApi: any;
     tableOptions: GridOptions;
     tableApi: GridApi;
-    panel: PanelManager;
+    panelManager: PanelManager;
     translations: any;
     configManager: ConfigManager;
     legendBlock: any;

--- a/lib/enhancedTable/index.js
+++ b/lib/enhancedTable/index.js
@@ -18,22 +18,22 @@ var TableBuilder = /** @class */ (function () {
     TableBuilder.prototype.init = function (mapApi) {
         var _this = this;
         this.mapApi = mapApi;
-        this.panel = new panel_manager_1.PanelManager(mapApi);
-        this.panel.reload = this.reloadTable.bind(this);
+        this.panelManager = new panel_manager_1.PanelManager(mapApi);
+        this.panelManager.reload = this.reloadTable.bind(this);
         this.mapApi.layers.reload.subscribe(function (baseLayer, interval) {
-            if (!interval && baseLayer === _this.panel.currentTableLayer) {
+            if (!interval && baseLayer === _this.panelManager.currentTableLayer) {
                 _this.reloadTable(baseLayer);
             }
         });
         this.mapApi.ui.configLegend.elementRemoved.subscribe(function (legendBlock) {
-            if (legendBlock === _this.panel.panelStateManager.legendBlock) {
-                _this.panel.close();
+            if (legendBlock === _this.panelManager.legendBlock) {
+                _this.panelManager.panel.close();
             }
         });
         // toggle the enhancedTable if toggleDataTable is called from Legend API
         this.mapApi.ui.configLegend.dataTableToggled.subscribe(function (legendBlock) {
             // Open the table if its closed, never been created or this is a different legend block
-            if (_this.panel.panel.isClosed || !_this.panel.panelStateManager || _this.panel.panelStateManager.legendBlock !== legendBlock) {
+            if (_this.panelManager.panel.isClosed || !_this.panelManager.panelStateManager || _this.panelManager.panelStateManager.legendBlock !== legendBlock) {
                 // creates a 'loader' panel to be opened if data hasn't loaded after 200ms
                 _this.deleteLoaderPanel();
                 _this.loadingPanel = new panel_loader_1.PanelLoader(_this.mapApi, legendBlock);
@@ -44,7 +44,7 @@ var TableBuilder = /** @class */ (function () {
                 _this.findMatchingLayer(legendBlock);
             }
             else {
-                _this.panel.close();
+                _this.panelManager.panel.close();
             }
         });
     };
@@ -65,7 +65,7 @@ var TableBuilder = /** @class */ (function () {
                 // if layer was created unsubscribe to layer added observable
                 // create + open the enhancedTable
                 this.legendBlock = legendBlock;
-                this.panel.setLegendBlock(legendBlock);
+                this.panelManager.setLegendBlock(legendBlock);
                 if (this.layerAdded !== undefined) {
                     this.layerAdded.unsubscribe();
                 }
@@ -89,15 +89,15 @@ var TableBuilder = /** @class */ (function () {
             // if no PanelStateManager exists for this BaseLayer, create a new one
             baseLayer.panelStateManager = new panel_state_manager_1.PanelStateManager(baseLayer, this.legendBlock);
         }
-        this.panel.panelStateManager = baseLayer.panelStateManager;
+        this.panelManager.panelStateManager = baseLayer.panelStateManager;
         var attrs = baseLayer.getAttributes();
         this.attributeHeaders = baseLayer.attributeHeaders;
         if (attrs.length === 0) {
             // make sure all attributes are added before creating the table (otherwise table displays without SVGs)
             this.mapApi.layers.attributesAdded.pipe(take_1.take(1)).subscribe(function (attrs) {
                 if (attrs.attributes.length > 0) {
-                    _this.configManager = new config_manager_1.ConfigManager(baseLayer, _this.panel);
-                    _this.panel.configManager = _this.configManager;
+                    _this.configManager = new config_manager_1.ConfigManager(baseLayer, _this.panelManager);
+                    _this.panelManager.configManager = _this.configManager;
                     _this.createTable(attrs);
                 }
                 else {
@@ -106,8 +106,8 @@ var TableBuilder = /** @class */ (function () {
             });
         }
         else {
-            this.configManager = new config_manager_1.ConfigManager(baseLayer, this.panel);
-            this.panel.configManager = this.configManager;
+            this.configManager = new config_manager_1.ConfigManager(baseLayer, this.panelManager);
+            this.panelManager.configManager = this.configManager;
             this.createTable({
                 attributes: attrs,
                 layer: baseLayer
@@ -163,7 +163,7 @@ var TableBuilder = /** @class */ (function () {
                                 ? !column.column.visible
                                 : undefined
                     };
-                    _this.panel.notVisible[colDef.field] =
+                    _this.panelManager.notVisible[colDef.field] =
                         _this.configManager.filteredAttributes.length === 0 ? false : column.column ? !column.column.visible : undefined;
                     // set up floating filters and column header
                     var fieldInfo = a.fields.find(function (field) { return field.name === columnName; });
@@ -175,17 +175,17 @@ var TableBuilder = /** @class */ (function () {
                             // floating filters of type number, date, text
                             // text can be of type text or selector
                             if (NUMBER_TYPES.indexOf(fieldInfo.type) > -1) {
-                                custom_floating_filters_1.setUpNumberFilter(colDef, isStatic, column.value, _this.tableOptions, _this.panel.panelStateManager);
+                                custom_floating_filters_1.setUpNumberFilter(colDef, isStatic, column.value, _this.tableOptions, _this.panelManager.panelStateManager);
                             }
                             else if (fieldInfo.type === DATE_TYPE) {
-                                custom_floating_filters_1.setUpDateFilter(colDef, isStatic, _this.mapApi, column.value, _this.panel.panelStateManager);
+                                custom_floating_filters_1.setUpDateFilter(colDef, isStatic, _this.mapApi, column.value, _this.panelManager.panelStateManager);
                             }
                             else if (fieldInfo.type === TEXT_TYPE && attrBundle.layer.table !== undefined) {
                                 if (isSelector) {
-                                    custom_floating_filters_1.setUpSelectorFilter(colDef, isStatic, column.value, _this.tableOptions, _this.mapApi, _this.panel.panelStateManager);
+                                    custom_floating_filters_1.setUpSelectorFilter(colDef, isStatic, column.value, _this.tableOptions, _this.mapApi, _this.panelManager.panelStateManager);
                                 }
                                 else {
-                                    custom_floating_filters_1.setUpTextFilter(colDef, isStatic, _this.configManager.lazyFilterEnabled, _this.configManager.searchStrictMatchEnabled, column.value, _this.mapApi, _this.panel.panelStateManager);
+                                    custom_floating_filters_1.setUpTextFilter(colDef, isStatic, _this.configManager.lazyFilterEnabled, _this.configManager.searchStrictMatchEnabled, column.value, _this.mapApi, _this.panelManager.panelStateManager);
                                 }
                             }
                         }
@@ -202,16 +202,16 @@ var TableBuilder = /** @class */ (function () {
             // Show toast on layer refresh is refresh interval is set
             var refreshInterval = _this.legendBlock.proxyWrapper.layerConfig.refreshInterval;
             if (refreshInterval) {
-                _this.panel.toastInterval = setInterval(function () {
-                    _this.panel.showToast();
+                _this.panelManager.toastInterval = setInterval(function () {
+                    _this.panelManager.showToast();
                 }, refreshInterval * 60000);
             }
-            _this.panel.open(_this.tableOptions, attrBundle.layer, _this);
+            _this.panelManager.open(_this.tableOptions, attrBundle.layer, _this);
             _this.tableApi = _this.tableOptions.api;
         });
     };
     TableBuilder.prototype.reloadTable = function (baseLayer) {
-        this.panel.close();
+        this.panelManager.panel.close();
         this.openTable(baseLayer);
     };
     return TableBuilder;

--- a/lib/enhancedTable/index.js
+++ b/lib/enhancedTable/index.js
@@ -25,8 +25,8 @@ var TableBuilder = /** @class */ (function () {
                 _this.reloadTable(baseLayer);
             }
         });
-        this.mapApi.layers.layerRemoved.subscribe(function (baseLayer) {
-            if (baseLayer === _this.panel.currentTableLayer) {
+        this.mapApi.ui.configLegend.elementRemoved.subscribe(function (legendBlock) {
+            if (legendBlock === _this.panel.panelStateManager.legendBlock) {
                 _this.panel.close();
             }
         });

--- a/lib/enhancedTable/main.css
+++ b/lib/enhancedTable/main.css
@@ -3735,7 +3735,10 @@ md-datepicker > div {
   text-overflow: ellipsis;
   white-space: nowrap;
   width: 100%;
-  overflow: hidden; }
+  overflow: hidden;
+  margin-top: 5px;
+  margin-bottom: 0;
+  line-height: 11px; }
 
 .md-title {
   display: block !important; }

--- a/lib/enhancedTable/panel-manager.d.ts
+++ b/lib/enhancedTable/panel-manager.d.ts
@@ -20,7 +20,10 @@ export declare class PanelManager {
      */
     prepListNavigation(): void;
     open(tableOptions: any, layer: any, tableBuilder: any): void;
-    close(): void;
+    /**
+     * Cleans up the table when the panel is being closed.
+     */
+    cleanUp(): void;
     onBtnExport(): void;
     onBtnPrint(): void;
     createHTMLTable(): string;

--- a/lib/enhancedTable/panel-manager.js
+++ b/lib/enhancedTable/panel-manager.js
@@ -33,8 +33,8 @@ var PanelManager = /** @class */ (function () {
         close.addClass('black md-ink-ripple');
         this.setSize();
         //destroy the table properly whenever the panel is closed
-        this.panel.closing.subscribe(function (response) {
-            _this.close();
+        this.panel.closing.subscribe(function () {
+            _this.cleanUp();
         });
     }
     Object.defineProperty(PanelManager.prototype, "panelStateManager", {
@@ -127,12 +127,12 @@ var PanelManager = /** @class */ (function () {
     PanelManager.prototype.open = function (tableOptions, layer, tableBuilder) {
         var _this = this;
         if (this.currentTableLayer === layer) {
-            this.close();
+            this.panel.close();
         }
         else {
             // close previous table properly if open
             if (this.currentTableLayer) {
-                this.close();
+                this.panel.close();
             }
             this.tableOptions = tableOptions;
             // set filter change flag to true
@@ -222,7 +222,10 @@ var PanelManager = /** @class */ (function () {
             };
         }
     };
-    PanelManager.prototype.close = function () {
+    /**
+     * Cleans up the table when the panel is being closed.
+     */
+    PanelManager.prototype.cleanUp = function () {
         this.panelStateManager.sortModel = this.tableOptions.api.getSortModel();
         if (this.gridBody !== undefined) {
             grid_accessibility_1.removeAccessibilityListeners(this.panel.element[0], this.gridBody);


### PR DESCRIPTION
## Link to issue number(s):
https://github.com/fgpv-vpgf/fgpv-vpgf/issues/3447
https://github.com/fgpv-vpgf/fgpv-vpgf/issues/2547

## Summary of the issue:
3447 - datatable did not close on dynamic layer removal unless all children removed
2547 - no way to get extent through API or set with `fit` parameter

## Description of how this pull request fixes the issue:
3447 - close datatable immediately on removal of any layer
2547 - modify the setter to a function with optional parameter and add get function

## Testing:

Testing Link: http://fgpv.cloudapp.net/demo/users/JahidAhmed/3447-legend-remove-observable/dev/samples/index-samples.html

-   [ ] Test specs are up-to-date & cover all changes/additions made by this PR.
-   [ ] `npm run test` passes locally.

<!-- Comment if additional testing was performed or if test specs are not suited to cover all cases. Provide links to external resources where appropriate.  -->

## Documentation

-   [ ] Documentation is up-to-date - any changes or additions have been noted
-   [ ] `changelog.md` has been updated

## Checklist

-   [ ] PR has only one commit (squash otherwise)
-   [ ] Commit message is descriptive

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/plugins/91)
<!-- Reviewable:end -->
