### PR TITLE
fix(enhancedTable): fix global filter console errors

### DIFF
--- a/enhancedTable/config-manager.ts
+++ b/enhancedTable/config-manager.ts
@@ -19,10 +19,10 @@ export class ConfigManager {
             layerEntries !== undefined) {
             // if these titles are not the same, and the baseLayer has layer entries
             // look for the layer entry with the matching name and set ITS table config as the table config
+            let that = this;
             layerEntries.forEach(entry => {
-                if (entry.proxyWrapper.name === this.panelManager.legendBlock.name) {
-                    this.tableConfig = entry.proxyWrapper.layerConfig.source.table;
-                }
+                this.tableConfig = entry.proxyWrapper.layerConfig.source.table !== undefined ?
+                    entry.proxyWrapper.layerConfig.source.table !== undefined : that.baseLayer.table;
             });
         } else {
             this.tableConfig = baseLayer.table;

--- a/enhancedTable/panel-manager.ts
+++ b/enhancedTable/panel-manager.ts
@@ -331,7 +331,7 @@ export class PanelManager {
         columns = columns ? columns : this.tableOptions.columnApi.getAllColumns();
         this.tableOptions.columnApi.autoSizeColumns(columns);
         columns.forEach(c => {
-        if (c.actualWidth > maxWidth) {
+            if (c.actualWidth > maxWidth) {
                 this.tableOptions.columnApi.setColumnWidth(c, maxWidth);
             }
         });
@@ -578,10 +578,10 @@ export class PanelManager {
                 Object.keys(filterModel).forEach(col => {
                     colStrs.push(filterToSql(col, filterModel[col]));
                 });
-                if (that.searchText) {
-                    const globalSearchVal = globalSearchToSql();
+                if (that.searchText && that.searchText.length > 2) {
+                    const globalSearchVal = globalSearchToSql() !== '' ? globalSearchToSql() : '1=2';
                     if (globalSearchVal) {
-                        // will be an empty string if there are no visible rows
+                        // do not push an empty global search
                         colStrs.push(globalSearchVal);
                     }
                 }
@@ -660,7 +660,8 @@ export class PanelManager {
                 let filteredColumns = [];
                 columns.forEach(column => {
                     for (let row of sortedRows) {
-                        if (re.test(row.data[column.colId].toUpperCase())) {
+                        const cellData = row.data[column.colId] === null ? null : row.data[column.colId].toString();
+                        if (cellData !== null && re.test(cellData.toUpperCase())) {
                             filteredColumns.push(`UPPER(${column.colId}) LIKE \'${filterVal}%\'`);
                         }
                     }

--- a/lib/enhancedTable/config-manager.js
+++ b/lib/enhancedTable/config-manager.js
@@ -1,5 +1,7 @@
 "use strict";
-Object.defineProperty(exports, "__esModule", { value: true });
+Object.defineProperty(exports, "__esModule", {
+    value: true
+});
 /**
  * Creates and manages one table config that corresponds to an enhancedTable.
  *
@@ -19,13 +21,14 @@ var ConfigManager = /** @class */ (function () {
             layerEntries !== undefined) {
             // if these titles are not the same, and the baseLayer has layer entries
             // look for the layer entry with the matching name and set ITS table config as the table config
+            let that = this;
             layerEntries.forEach(function (entry) {
                 if (entry.proxyWrapper.name === _this.panelManager.legendBlock.name) {
-                    _this.tableConfig = entry.proxyWrapper.layerConfig.source.table;
+                    _this.tableConfig = entry.proxyWrapper.layerConfig.source.table !== undefined ?
+                        entry.proxyWrapper.layerConfig.source.table !== undefined : that.baseLayer.table;
                 }
             });
-        }
-        else {
+        } else {
             this.tableConfig = baseLayer.table;
         }
         this.searchEnabled = this.tableConfig.search && this.tableConfig.search.enabled;

--- a/lib/enhancedTable/panel-manager.js
+++ b/lib/enhancedTable/panel-manager.js
@@ -1,5 +1,7 @@
 "use strict";
-Object.defineProperty(exports, "__esModule", { value: true });
+Object.defineProperty(exports, "__esModule", {
+    value: true
+});
 var ag_grid_community_1 = require("ag-grid-community");
 var templates_1 = require("./templates");
 var details_and_zoom_buttons_1 = require("./details-and-zoom-buttons");
@@ -76,21 +78,18 @@ var PanelManager = /** @class */ (function () {
                 if (event.keyCode === 9 && focusedCell === null) {
                     // if first tab into grid body automatically focus on first cell
                     that.tableOptions.api.setFocusedCell(0, 'rvSymbol');
-                }
-                else if (focusedCell !== null && event.keyCode === 27) {
+                } else if (focusedCell !== null && event.keyCode === 27) {
                     // on esc key, clear focused cell
                     that.tableOptions.api.clearFocusedCell();
                 }
-            }
-            else {
+            } else {
                 that.tableOptions.api.clearFocusedCell();
             }
             if ((event.keyCode !== 9 && event.keyCode !== 27) || ($('.element-focused')[0] === undefined && inList)) {
                 // if you are not tabbing or you are tabbing within a list or you're not pressing the escape key
                 // set body to be scrollable
                 $('.ag-body-viewport')[0].style.position = 'initial';
-            }
-            else {
+            } else {
                 // if you are tabbing between lists, body should be absolute
                 $('.ag-body-viewport')[0].style.position = 'absolute';
             }
@@ -127,8 +126,7 @@ var PanelManager = /** @class */ (function () {
         var _this = this;
         if (this.currentTableLayer === layer) {
             this.panel.close();
-        }
-        else {
+        } else {
             // close previous table properly if open
             if (this.currentTableLayer) {
                 this.panel.close();
@@ -200,10 +198,14 @@ var PanelManager = /** @class */ (function () {
                     // determine if columnState is not visible either through saved state or through column definition
                     var columnState = _this.panelStateManager.columnState;
                     var notVisible = columnState !== null &&
-                        columnState.find(function (state) { return state.colId === column.field; }) !== undefined ?
+                        columnState.find(function (state) {
+                            return state.colId === column.field;
+                        }) !== undefined ?
                         columnState : column.hide;
                     if (column.floatingFilterComponentParams.defaultValue !== undefined && notVisible === true) {
-                        var matchingCol = _this.columnMenuCtrl.columnVisibilities.find(function (col) { return col.id === column.field; });
+                        var matchingCol = _this.columnMenuCtrl.columnVisibilities.find(function (col) {
+                            return col.id === column.field;
+                        });
                         // temporarily show column filter of hidden columns (so that table gets filtered properly)
                         _this.columnMenuCtrl.toggleColumn(matchingCol);
                         // then hide column (to respect config specifications)
@@ -217,8 +219,7 @@ var PanelManager = /** @class */ (function () {
                     setTimeout(function () {
                         tableBuilder.deleteLoaderPanel();
                     }, 400);
-                }
-                else {
+                } else {
                     tableBuilder.deleteLoaderPanel();
                 }
                 _this.panel.open();
@@ -247,7 +248,9 @@ var PanelManager = /** @class */ (function () {
     };
     PanelManager.prototype.onBtnExport = function () {
         var dataColumns = this.tableOptions.columnApi.getAllDisplayedVirtualColumns().slice(3);
-        this.tableOptions.api.exportDataAsCsv({ columnKeys: dataColumns });
+        this.tableOptions.api.exportDataAsCsv({
+            columnKeys: dataColumns
+        });
     };
     PanelManager.prototype.onBtnPrint = function () {
         var win = window.open('../print-table.html', '_blank');
@@ -269,10 +272,13 @@ var PanelManager = /** @class */ (function () {
     };
     PanelManager.prototype.setSize = function () {
         if (this.maximized) {
-            this.panel.element.css({ bottom: '0' });
-        }
-        else {
-            this.panel.element.css({ bottom: '50%' });
+            this.panel.element.css({
+                bottom: '0'
+            });
+        } else {
+            this.panel.element.css({
+                bottom: '50%'
+            });
         }
     };
     PanelManager.prototype.isMobile = function () {
@@ -303,11 +309,12 @@ var PanelManager = /** @class */ (function () {
         var availableWidth = panel.getWidthForSizeColsToFit();
         var usedWidth = panel.columnController.getWidthOfColsInList(columns);
         if (usedWidth < availableWidth) {
-            var symbolCol = columns.find(function (c) { return c.colId === 'zoom'; });
+            var symbolCol = columns.find(function (c) {
+                return c.colId === 'zoom';
+            });
             if (columns.length === 3) {
                 symbolCol.maxWidth = undefined;
-            }
-            else {
+            } else {
                 symbolCol.maxWidth = 40;
             }
             this.tableOptions.api.sizeColumnsToFit();
@@ -365,23 +372,25 @@ var PanelManager = /** @class */ (function () {
     PanelManager.prototype.angularHeader = function () {
         var that = this;
         this.mapApi.agControllerRegister('ToastCtrl', ['$scope', '$mdToast', '$rootElement', function ($scope, $mdToast, $rootElement) {
-                that.showToast = function () {
-                    if ($rootElement.find('.table-toast').length === 0) {
-                        $mdToast.show({
-                            template: templates_1.TABLE_UPDATE_TEMPLATE,
-                            parent: that.panel.element[0],
-                            position: 'bottom rv-flex-global',
-                            hideDelay: false,
-                            controller: 'ToastCtrl'
-                        });
-                    }
-                };
-                $scope.reloadTable = function () {
-                    that.reload(that.currentTableLayer);
-                    $mdToast.hide();
-                };
-                $scope.closeToast = function () { return $mdToast.hide(); };
-            }]);
+            that.showToast = function () {
+                if ($rootElement.find('.table-toast').length === 0) {
+                    $mdToast.show({
+                        template: templates_1.TABLE_UPDATE_TEMPLATE,
+                        parent: that.panel.element[0],
+                        position: 'bottom rv-flex-global',
+                        hideDelay: false,
+                        controller: 'ToastCtrl'
+                    });
+                }
+            };
+            $scope.reloadTable = function () {
+                that.reload(that.currentTableLayer);
+                $mdToast.hide();
+            };
+            $scope.closeToast = function () {
+                return $mdToast.hide();
+            };
+        }]);
         this.mapApi.agControllerRegister('SearchCtrl', function () {
             that.searchText = that.configManager.defaultGlobalSearch;
             this.searchText = that.searchText ? that.searchText : '';
@@ -391,8 +400,7 @@ var PanelManager = /** @class */ (function () {
                 if (this.searchText.length > 2) {
                     that.tableOptions.api.setQuickFilter(this.searchText);
                     that.panelRowsManager.quickFilterText = this.searchText;
-                }
-                else {
+                } else {
                     that.tableOptions.api.setQuickFilter('');
                     that.panelRowsManager.quickFilterText = '';
                 }
@@ -441,8 +449,7 @@ var PanelManager = /** @class */ (function () {
                 // On toggle, filter by extent or remove the extent filter
                 if (that.panelStateManager.filterByExtent) {
                     that.panelRowsManager.filterByExtent(that.mapApi.mapI.extent);
-                }
-                else {
+                } else {
                     that.panelRowsManager.fetchValidOids();
                 }
             };
@@ -482,8 +489,7 @@ var PanelManager = /** @class */ (function () {
                     });
                     // if column filters don't exist or are static, clearFilters button is disabled
                     return noFilters && !that.searchText;
-                }
-                else {
+                } else {
                     return true;
                 }
             };
@@ -508,17 +514,18 @@ var PanelManager = /** @class */ (function () {
                 that.filtersChanged = false;
                 that.hideToolTips();
             };
-            // get filter SQL qeury string
+            // get filter SQL query string
             function getFiltersQuery() {
                 var filterModel = that.tableOptions.api.getFilterModel();
                 var colStrs = [];
                 Object.keys(filterModel).forEach(function (col) {
                     colStrs.push(filterToSql(col, filterModel[col]));
                 });
-                if (that.searchText) {
-                    var globalSearchVal = globalSearchToSql();
+                if (that.searchText && that.searchText.length > 2) {
+                    // only want to activate appy to map for global query strings greater than 2 chars
+                    var globalSearchVal = globalSearchToSql() !== '' ? globalSearchToSql() : '1=2';
                     if (globalSearchVal) {
-                        // will be an empty string if there are no visible rows
+                        // do not push an empty global search
                         colStrs.push(globalSearchVal);
                     }
                 }
@@ -531,8 +538,7 @@ var PanelManager = /** @class */ (function () {
                     case 'text':
                         if (column.isSelector) {
                             return "UPPER(" + col + ") IN (" + colFilter.filter.toUpperCase() + ")";
-                        }
-                        else {
+                        } else {
                             var val = colFilter.filter.replace(/'/g, /''/);
                             if (val !== '') {
                                 if (that.configManager.lazyFilterEnabled) {
@@ -542,32 +548,32 @@ var PanelManager = /** @class */ (function () {
                                 return "UPPER(" + col + ") LIKE '" + val.replace(/\*/g, '%').toUpperCase() + "%'";
                             }
                         }
-                    case 'number':
-                        switch (colFilter.type) {
-                            case 'greaterThanOrEqual':
-                                return col + " >= " + colFilter.filter;
-                            case 'lessThanOrEqual':
-                                return col + " <= " + colFilter.filter;
-                            case 'inRange':
-                                return col + " >= " + colFilter.filter + " AND " + col + " <= " + colFilter.filterTo;
-                            default:
-                                break;
-                        }
-                    case 'date':
-                        var dateFrom = new Date(colFilter.dateFrom);
-                        var dateTo = new Date(colFilter.dateTo);
-                        var from = dateFrom ? dateFrom.getMonth() + 1 + "/" + dateFrom.getDate() + "/" + dateFrom.getFullYear() : undefined;
-                        var to = dateTo ? dateTo.getMonth() + 1 + "/" + dateTo.getDate() + "/" + dateTo.getFullYear() : undefined;
-                        switch (colFilter.type) {
-                            case 'greaterThanOrEqual':
-                                return col + " >= DATE '" + from + "'";
-                            case 'lessThanOrEqual':
-                                return col + " <= DATE '" + from + "'"; // ag-grid uses from for a single upper limit as well
-                            case 'inRange':
-                                return col + " >= DATE '" + from + "' AND " + col + " <= DATE '" + to + "'";
-                            default:
-                                break;
-                        }
+                        case 'number':
+                            switch (colFilter.type) {
+                                case 'greaterThanOrEqual':
+                                    return col + " >= " + colFilter.filter;
+                                case 'lessThanOrEqual':
+                                    return col + " <= " + colFilter.filter;
+                                case 'inRange':
+                                    return col + " >= " + colFilter.filter + " AND " + col + " <= " + colFilter.filterTo;
+                                default:
+                                    break;
+                            }
+                            case 'date':
+                                var dateFrom = new Date(colFilter.dateFrom);
+                                var dateTo = new Date(colFilter.dateTo);
+                                var from = dateFrom ? dateFrom.getMonth() + 1 + "/" + dateFrom.getDate() + "/" + dateFrom.getFullYear() : undefined;
+                                var to = dateTo ? dateTo.getMonth() + 1 + "/" + dateTo.getDate() + "/" + dateTo.getFullYear() : undefined;
+                                switch (colFilter.type) {
+                                    case 'greaterThanOrEqual':
+                                        return col + " >= DATE '" + from + "'";
+                                    case 'lessThanOrEqual':
+                                        return col + " <= DATE '" + from + "'"; // ag-grid uses from for a single upper limit as well
+                                    case 'inRange':
+                                        return col + " >= DATE '" + from + "' AND " + col + " <= DATE '" + to + "'";
+                                    default:
+                                        break;
+                                }
                 }
             }
             // convert global search to SQL string filter of columns excluding unfiltered columns
@@ -585,13 +591,16 @@ var PanelManager = /** @class */ (function () {
                 var sortedRows = that.tableOptions.api.rowModel.rowsToDisplay;
                 var columns = that.tableOptions.columnApi
                     .getAllDisplayedColumns()
-                    .filter(function (column) { return column.colDef.filter === 'agTextColumnFilter'; });
+                    .filter(function (column) {
+                        return column.colDef.filter === 'agTextColumnFilter';
+                    });
                 columns.splice(0, 3);
                 var filteredColumns = [];
                 columns.forEach(function (column) {
                     for (var _i = 0, sortedRows_1 = sortedRows; _i < sortedRows_1.length; _i++) {
                         var row = sortedRows_1[_i];
-                        if (re.test(row.data[column.colId].toUpperCase())) {
+                        var cellData = row.data[column.colId] === null ? null : row.data[column.colId].toString();
+                        if (cellData !== null && re.test(cellData.toUpperCase())) {
                             filteredColumns.push("UPPER(" + column.colId + ") LIKE '" + filterVal + "%'");
                         }
                     }
@@ -603,11 +612,19 @@ var PanelManager = /** @class */ (function () {
             that.columnMenuCtrl = this;
             this.columns = that.tableOptions.columnDefs;
             this.columnVisibilities = this.columns
-                .filter(function (element) { return element.headerName; })
+                .filter(function (element) {
+                    return element.headerName;
+                })
                 .map(function (element) {
-                return { id: element.field, title: element.headerName, visibility: !element.hide };
-            })
-                .sort(function (firstEl, secondEl) { return firstEl['title'].localeCompare(secondEl['title']); });
+                    return {
+                        id: element.field,
+                        title: element.headerName,
+                        visibility: !element.hide
+                    };
+                })
+                .sort(function (firstEl, secondEl) {
+                    return firstEl['title'].localeCompare(secondEl['title']);
+                });
             // toggle column visibility
             this.toggleColumn = function (col) {
                 var column = that.tableOptions.columnApi.getColumn(col.id);


### PR DESCRIPTION
## Link to issue number(s):
Closes: https://github.com/fgpv-vpgf/fgpv-vpgf/issues/3506

## Summary of the issue:
Was a waterfall of errors with `sample 76` caused by reasons:
- when converting to uppercase, value was null
- when converting to uppercase, value was a string

Also Apply to Map had issues: 
- global query strings of less than three chars would activate `Apply to Map`
- `Apply to Map` was not activated for global query strings that make table empty

Also there was an issue with `layerEntries` erroring out. 


## Description of how this pull request fixes the issue:

- added check for null values and converted each value to string
- added check for not activating `Apply to Map` for global query strings greater than 2
- added check for activating `Apply to Map` for global query strings that make table empty `1=2`
- fixed `layerEntry` errror out issue

## Testing:

`sample 76`

http://fgpv.cloudapp.net/demo/users/ShrutiVellanki/error-waterfall/dev/samples/index-samples.html?sample=76

-   [ ] Test specs are up-to-date & cover all changes/additions made by this PR.
-   [ ] `npm run test` passes locally.

<!-- Comment if additional testing was performed or if test specs are not suited to cover all cases. Provide links to external resources where appropriate.  -->

## Documentation

-   [x] Documentation is up-to-date - any changes or additions have been noted
-   [ ] `changelog.md` has been updated

## Checklist

-   [x] PR has only one commit (squash otherwise)
-   [x] Commit message is descriptive

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/plugins/97)
<!-- Reviewable:end -->
