### PR TITLE
fix(plugins): version bump

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@fgpv/rv-plugins",
-    "version": "3.0.0-13",
+    "version": "3.0.0",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@fgpv/rv-plugins",
-    "version": "3.0.0-13",
+    "version": "3.0.0",
     "description": "Plugins for the RAMP viewer supported by the core team.",
     "scripts": {
         "build": "webpack --config ./bin/build/webpack.config.js && npm run prepublishOnly",


### PR DESCRIPTION
## Link to issue number(s):

Bumps plugins up to `v3.0.0`: 

Tag: https://github.com/fgpv-vpgf/plugins/tree/v3.0.0
On npm: https://registry.npmjs.org/@fgpv/rv-plugins/ `v3.0.0` should show up there after a little bit

## Summary of the issue:

## Description of how this pull request fixes the issue:

## Testing:

-   [ ] Test specs are up-to-date & cover all changes/additions made by this PR.
-   [ ] `npm run test` passes locally.

<!-- Comment if additional testing was performed or if test specs are not suited to cover all cases. Provide links to external resources where appropriate.  -->

## Documentation

-   [ ] Documentation is up-to-date - any changes or additions have been noted
-   [ ] `changelog.md` has been updated

## Checklist

-   [ ] PR has only one commit (squash otherwise)
-   [ ] Commit message is descriptive

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/plugins/101)
<!-- Reviewable:end -->
