### PR TITLE
fix(table): compare apiLayer instead of legendBlock on reload

### DIFF
--- a/enhancedTable/index.ts
+++ b/enhancedTable/index.ts
@@ -35,9 +35,9 @@ export default class TableBuilder {
         });
 
         // toggle the enhancedTable if toggleDataTable is called from Legend API
-        this.mapApi.ui.configLegend.dataTableToggled.subscribe(legendBlock => {
-            // Open the table if its closed, never been created or this is a different legend block
-            if (this.panelManager.panel.isClosed || !this.panelManager.panelStateManager || this.panelManager.panelStateManager.legendBlock !== legendBlock) {
+        this.mapApi.ui.configLegend.dataTableToggled.subscribe(({ apiLayer, legendBlock }) => {
+            // Open the table if its closed, never been created or this is a different layer (by comparing API layers, instead of legendBlocks, since reload changes legendBlock)
+            if (this.panelManager.panel.isClosed || !this.panelManager.panelStateManager || this.panelManager.panelStateManager.baseLayer !== apiLayer) {
                 // creates a 'loader' panel to be opened if data hasn't loaded after 200ms
                 this.deleteLoaderPanel();
                 this.loadingPanel = new PanelLoader(this.mapApi, legendBlock);

--- a/lib/enhancedTable/config-manager.js
+++ b/lib/enhancedTable/config-manager.js
@@ -1,7 +1,5 @@
 "use strict";
-Object.defineProperty(exports, "__esModule", {
-    value: true
-});
+Object.defineProperty(exports, "__esModule", { value: true });
 /**
  * Creates and manages one table config that corresponds to an enhancedTable.
  *
@@ -21,16 +19,18 @@ var ConfigManager = /** @class */ (function () {
             layerEntries !== undefined) {
             // if these titles are not the same, and the baseLayer has layer entries
             // look for the layer entry with the matching name and set ITS table config as the table config
-            var that = this;
+            var that_1 = this;
             layerEntries.forEach(function (entry) {
-                if (entry.proxyWrapper !== undefined && entry.proxyWrapper.name === that.panelManager.legendBlock.name) {
-                    that.tableConfig = entry.proxyWrapper.layerConfig.source.table !== undefined ?
-                        entry.proxyWrapper.layerConfig.source.table : that.baseLayer.table;
-                } else {
-                    that.tableConfig = that.baseLayer.table;
+                if (entry.proxyWrapper !== undefined && entry.proxyWrapper.name === _this.panelManager.legendBlock.name) {
+                    _this.tableConfig = entry.proxyWrapper.layerConfig.source.table !== undefined ?
+                        entry.proxyWrapper.layerConfig.source.table : that_1.baseLayer.table;
+                }
+                else {
+                    _this.tableConfig = that_1.baseLayer.table;
                 }
             });
-        } else {
+        }
+        else {
             this.tableConfig = baseLayer.table;
         }
         this.searchEnabled = this.tableConfig.search && this.tableConfig.search.enabled;

--- a/lib/enhancedTable/index.js
+++ b/lib/enhancedTable/index.js
@@ -31,9 +31,10 @@ var TableBuilder = /** @class */ (function () {
             }
         });
         // toggle the enhancedTable if toggleDataTable is called from Legend API
-        this.mapApi.ui.configLegend.dataTableToggled.subscribe(function (legendBlock) {
-            // Open the table if its closed, never been created or this is a different legend block
-            if (_this.panelManager.panel.isClosed || !_this.panelManager.panelStateManager || _this.panelManager.panelStateManager.legendBlock !== legendBlock) {
+        this.mapApi.ui.configLegend.dataTableToggled.subscribe(function (_a) {
+            var apiLayer = _a.apiLayer, legendBlock = _a.legendBlock;
+            // Open the table if its closed, never been created or this is a different layer (by comparing API layers, instead of legendBlocks, since reload changes legendBlock)
+            if (_this.panelManager.panel.isClosed || !_this.panelManager.panelStateManager || _this.panelManager.panelStateManager.baseLayer !== apiLayer) {
                 // creates a 'loader' panel to be opened if data hasn't loaded after 200ms
                 _this.deleteLoaderPanel();
                 _this.loadingPanel = new panel_loader_1.PanelLoader(_this.mapApi, legendBlock);


### PR DESCRIPTION
## Link to issue number(s):
https://github.com/fgpv-vpgf/fgpv-vpgf/issues/3509

## Summary of the issue:
Table did not build successfully because it did not recognize it was already open

## Description of how this pull request fixes the issue:
Since the table is still open after reload, it now closes it as expected

## [Testing](http://fgpv.cloudapp.net/demo/users/JahidAhmed/3509-rebuild-table-on-reload/dev/samples/index-samples.html):

-   ~~[ ] Test specs are up-to-date & cover all changes/additions made by this PR.~~
-   ~~[ ] `npm run test` passes locally.~~

<!-- Comment if additional testing was performed or if test specs are not suited to cover all cases. Provide links to external resources where appropriate.  -->

## Documentation

-   ~~[ ] Documentation is up-to-date - any changes or additions have been noted~~
-   ~~[ ] `changelog.md` has been updated~~

## Checklist

-   [x] PR has only one commit (squash otherwise)
-   [x] Commit message is descriptive

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/plugins/104)
<!-- Reviewable:end -->
