### PR TITLE
fix(enhancedTable): column order respects config

### DIFF
--- a/enhancedTable/index.ts
+++ b/enhancedTable/index.ts
@@ -135,7 +135,14 @@ export default class TableBuilder {
         const layerProxy = attrBundle.layer._layerProxy;
 
         layerProxy.formattedAttributes.then(a => {
-            Object.keys(a.rows[0]).forEach(columnName => {
+
+            // get column order according to the config if defined
+            // else get default columns
+            const columns = Object.keys(this.configManager.columnConfigs).length > 0 ?
+                ['rvInteractive', 'rvSymbol', ...Object.keys(this.configManager.columnConfigs)] :
+                Object.keys(a.rows[0]);
+
+            columns.forEach(columnName => {
                 if (
                     columnName === 'rvSymbol' ||
                     columnName === 'rvInteractive' ||

--- a/lib/enhancedTable/index.js
+++ b/lib/enhancedTable/index.js
@@ -131,7 +131,11 @@ var TableBuilder = /** @class */ (function () {
         var cols = [];
         var layerProxy = attrBundle.layer._layerProxy;
         layerProxy.formattedAttributes.then(function (a) {
-            Object.keys(a.rows[0]).forEach(function (columnName) {
+            // get column order according to the config if defined
+            // else get default columns
+            var columns = Object.keys(_this.configManager.columnConfigs).length > 0 ? ['rvInteractive', 'rvSymbol'].concat(Object.keys(_this.configManager.columnConfigs)) :
+                Object.keys(a.rows[0]);
+            columns.forEach(function (columnName) {
                 if (columnName === 'rvSymbol' ||
                     columnName === 'rvInteractive' ||
                     _this.configManager.filteredAttributes.length === 0 ||


### PR DESCRIPTION
## Link to issue number
Closes: https://github.com/fgpv-vpgf/fgpv-vpgf/issues/3589

## Summary of the issue:
Table did not respect column order as defined in config

## Description of how this pull request fixes the issue:
Table respects column order if defined, and sets default column order if not defined

## Testing:

-   [ ] Test specs are up-to-date & cover all changes/additions made by this PR.
-   [ ] `npm run test` passes locally.

<!-- Comment if additional testing was performed or if test specs are not suited to cover all cases. Provide links to external resources where appropriate.  -->

## Documentation

-   [x] Documentation is up-to-date - any changes or additions have been noted
-   [ ] `changelog.md` has been updated

## Checklist

-   [x] PR has only one commit (squash otherwise)
-   [x] Commit message is descriptive

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/plugins/109)
<!-- Reviewable:end -->
