### PR TITLE
fix(enhancedTable): number filter displays empty value properly

### DIFF
--- a/enhancedTable/templates.ts
+++ b/enhancedTable/templates.ts
@@ -148,8 +148,8 @@ export const ZOOM_TEMPLATE = (oid) =>
     </button>`;
 
 export const NUMBER_FILTER_TEMPLATE = (value, isStatic) => {
-    const minVal = (value === undefined) ? '' : (value.split(',')[0] !== '') ? parseInt(value.split(',')[0]) : '';
-    const maxVal = (value === undefined) ? '' : (value.split(',')[1] !== '') ? parseInt(value.split(',')[1]) : '';
+    const minVal = (value === undefined) ? '' : (value.split(',')[0] !== 'null') ? parseInt(value.split(',')[0]) : '';
+    const maxVal = (value === undefined) ? '' : (value.split(',')[1] !== 'null') ? parseInt(value.split(',')[1]) : '';
     if (isStatic === false) {
         return `<input class="rv-min" style="width:50%" type="text" placeholder="min" value='${minVal}'/>
          <input class="rv-max" style="width:50%" type="text" placeholder="max" value='${maxVal}'/>`;

--- a/lib/enhancedTable/templates.js
+++ b/lib/enhancedTable/templates.js
@@ -15,8 +15,8 @@ exports.ZOOM_TEMPLATE = function (oid) {
     return "<button ng-controller='DetailsAndZoomCtrl as ctrl' ng-click='ctrl.zoomToFeature(" + oid + ")'  md-ink-ripple class='md-icon-button rv-icon-16 md-button ng-scope enhanced-table-zoom' aria-label=\"{{ 'plugins.enhancedTable.detailsAndZoom.zoom' | translate }}\">\n        <md-icon md-svg-src=\"action:zoom_in\" aria-hidden='false'>\n            <md-tooltip  md-direction=\"top\">{{ 'plugins.enhancedTable.detailsAndZoom.zoom' | translate }}</md-tooltip>\n        </md-icon>\n    </button>";
 };
 exports.NUMBER_FILTER_TEMPLATE = function (value, isStatic) {
-    var minVal = (value === undefined) ? '' : (value.split(',')[0] !== '') ? parseInt(value.split(',')[0]) : '';
-    var maxVal = (value === undefined) ? '' : (value.split(',')[1] !== '') ? parseInt(value.split(',')[1]) : '';
+    var minVal = (value === undefined) ? '' : (value.split(',')[0] !== 'null') ? parseInt(value.split(',')[0]) : '';
+    var maxVal = (value === undefined) ? '' : (value.split(',')[1] !== 'null') ? parseInt(value.split(',')[1]) : '';
     if (isStatic === false) {
         return "<input class=\"rv-min\" style=\"width:50%\" type=\"text\" placeholder=\"min\" value='" + minVal + "'/>\n         <input class=\"rv-max\" style=\"width:50%\" type=\"text\" placeholder=\"max\" value='" + maxVal + "'/>";
     }


### PR DESCRIPTION
## Link to issue number(s):
https://github.com/fgpv-vpgf/fgpv-vpgf/issues/3632

## Summary of the issue:
When a value is entered into only one of the `max` and `min` column filters, the value of the empty field when the table is closed and reopened is `NaN`.

## Description of how this pull request fixes the issue:
The empty value no longer reads `NaN`.

## Testing:

-   [ ] Test specs are up-to-date & cover all changes/additions made by this PR.
-   [ ] `npm run test` passes locally.

<!-- Comment if additional testing was performed or if test specs are not suited to cover all cases. Provide links to external resources where appropriate.  -->

## Documentation

-   [ ] Documentation is up-to-date - any changes or additions have been noted
-   [ ] `changelog.md` has been updated

## Checklist

-   [x] PR has only one commit (squash otherwise)
-   [x] Commit message is descriptive

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/plugins/116)
<!-- Reviewable:end -->
