### PR TITLE
fix(enhancedTable): fix broken table when row contains complex values

### DIFF
--- a/enhancedTable/index.ts
+++ b/enhancedTable/index.ts
@@ -131,6 +131,7 @@ export default class TableBuilder {
     }
 
     createTable(attrBundle: AttrBundle) {
+        const self = this;
         let cols: Array<any> = [];
         const layerProxy = attrBundle.layer._layerProxy;
 
@@ -171,7 +172,10 @@ export default class TableBuilder {
                         floatingFilterComponentParams: { suppressFilterButton: true, mapApi: this.mapApi },
                         floatingFilterComponent: undefined,
                         cellRenderer: function (cell) {
-                            return cell.value;
+                            const translated = $(`<span>{{ 'plugins.enhancedTable.table.complexValue' | translate }}</span>`);
+                            self.mapApi.$compile(translated);
+
+                            return cell.value ? (typeof cell.value === 'object' ? translated[0] : cell.value) : '';
                         },
                         suppressSorting: false,
                         suppressFilter: column.searchDisabled,
@@ -401,7 +405,8 @@ TableBuilder.prototype.translations = {
                 clear: 'Clear filters',
                 apply: 'Apply filters to map'
             },
-            hideColumns: 'Hide columns'
+            hideColumns: 'Hide columns',
+            complexValue: 'Complex Value'
         },
         menu: {
             split: 'Split View',
@@ -436,7 +441,8 @@ TableBuilder.prototype.translations = {
                 clear: 'Effacer les filtres',
                 apply: 'Appliquer des filtres à la carte' // TODO: Add official French translation
             },
-            hideColumns: 'Masquer les colonnes' // TODO: Add Official French translation
+            hideColumns: 'Masquer les colonnes', // TODO: Add Official French translation
+            complexValue: 'Valeur Complexes'
         },
         menu: {
             split: 'Diviser la vue',

--- a/lib/enhancedTable/index.js
+++ b/lib/enhancedTable/index.js
@@ -128,6 +128,7 @@ var TableBuilder = /** @class */ (function () {
     };
     TableBuilder.prototype.createTable = function (attrBundle) {
         var _this = this;
+        var self = this;
         var cols = [];
         var layerProxy = attrBundle.layer._layerProxy;
         layerProxy.formattedAttributes.then(function (a) {
@@ -160,7 +161,9 @@ var TableBuilder = /** @class */ (function () {
                         floatingFilterComponentParams: { suppressFilterButton: true, mapApi: _this.mapApi },
                         floatingFilterComponent: undefined,
                         cellRenderer: function (cell) {
-                            return cell.value;
+                            var translated = $("<span>{{ 'plugins.enhancedTable.table.complexValue' | translate }}</span>");
+                            self.mapApi.$compile(translated);
+                            return cell.value ? (typeof cell.value === 'object' ? translated[0] : cell.value) : '';
                         },
                         suppressSorting: false,
                         suppressFilter: column.searchDisabled,
@@ -305,7 +308,8 @@ TableBuilder.prototype.translations = {
                 clear: 'Clear filters',
                 apply: 'Apply filters to map'
             },
-            hideColumns: 'Hide columns'
+            hideColumns: 'Hide columns',
+            complexValue: 'Complex Value'
         },
         menu: {
             split: 'Split View',
@@ -340,7 +344,8 @@ TableBuilder.prototype.translations = {
                 clear: 'Effacer les filtres',
                 apply: 'Appliquer des filtres à la carte' // TODO: Add official French translation
             },
-            hideColumns: 'Masquer les colonnes' // TODO: Add Official French translation
+            hideColumns: 'Masquer les colonnes',
+            complexValue: 'Valeur Complexes'
         },
         menu: {
             split: 'Diviser la vue',


### PR DESCRIPTION
## Link to issue number(s):
https://github.com/fgpv-vpgf/fgpv-vpgf/issues/3634

## Summary of the issue:
When trying to open the datagrid of some WFS layers, the table would never load. This was due to the fact that WFS layers can have attributes of type `object`. 

## Description of how this pull request fixes the issue:
This PR fixes the problem by temporarily replacing objects with `Complex Value` so the table opens. This PR is mainly just so the table will open again. A more permanent solution to this problem should be found in the future.

## Testing:

-   [ ] Test specs are up-to-date & cover all changes/additions made by this PR.
-   [ ] `npm run test` passes locally.

<!-- Comment if additional testing was performed or if test specs are not suited to cover all cases. Provide links to external resources where appropriate.  -->

## Documentation

-   [ ] Documentation is up-to-date - any changes or additions have been noted
-   [ ] `changelog.md` has been updated

## Checklist

-   [x] PR has only one commit (squash otherwise)
-   [x] Commit message is descriptive

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/plugins/118)
<!-- Reviewable:end -->
