### PR TITLE
fix(enhancedTable): fix grid special chars filtering

### DIFF
--- a/enhancedTable/custom-floating-filters.ts
+++ b/enhancedTable/custom-floating-filters.ts
@@ -215,9 +215,14 @@ export class TextFloatingFilter {
 
     /** Helper function to determine filter model */
     getModel(): any {
+        let newFilter = this.scope.input;
+        if (newFilter && typeof newFilter === 'string') {
+            const escRegex = /[(!"#$&\'+,.\\\/:;<=>?@[\]^`{|}~)]/g;
+            newFilter = newFilter.replace(escRegex, '\\$&');
+        }
         return {
             type: 'contains',
-            filter: this.scope.input
+            filter: newFilter
         }
     }
 

--- a/enhancedTable/panel-state-manager.ts
+++ b/enhancedTable/panel-state-manager.ts
@@ -23,7 +23,12 @@ export class PanelStateManager {
     }
 
     setColumnFilter(colDefField: string, filterValue: any): void {
-        this.columnFilters[colDefField] = filterValue;
+        let newFilterValue = filterValue;
+        if (filterValue && typeof filterValue === 'string') {
+            const escRegex = /[(!"#$%&\'+,.\\\/:;<=>?@[\]^`{|}~)]/g;
+            newFilterValue = filterValue.replace(escRegex, '\\$&');
+        }
+        this.columnFilters[colDefField] = newFilterValue;
     }
 
     get sortModel(): any {

--- a/lib/enhancedTable/custom-floating-filters.js
+++ b/lib/enhancedTable/custom-floating-filters.js
@@ -194,9 +194,14 @@ var TextFloatingFilter = /** @class */ (function () {
     };
     /** Helper function to determine filter model */
     TextFloatingFilter.prototype.getModel = function () {
+        var newFilter = this.scope.input;
+        if (newFilter && typeof newFilter === 'string') {
+            var escRegex = /[(!"#$&\'+,.\\\/:;<=>?@[\]^`{|}~)]/g;
+            newFilter = newFilter.replace(escRegex, '\\$&');
+        }
         return {
             type: 'contains',
-            filter: this.scope.input
+            filter: newFilter
         };
     };
     /** Return component GUI */

--- a/lib/enhancedTable/panel-manager.js
+++ b/lib/enhancedTable/panel-manager.js
@@ -507,7 +507,7 @@ var PanelManager = /** @class */ (function () {
                 that.filtersChanged = false;
                 that.hideToolTips();
             };
-            // get filter SQL qeury string
+            // get filter SQL query string
             function getFiltersQuery() {
                 var filterModel = that.tableOptions.api.getFilterModel();
                 var colStrs = [];
@@ -534,11 +534,34 @@ var PanelManager = /** @class */ (function () {
                         else {
                             var val = colFilter.filter.replace(/'/g, /''/);
                             if (val !== '') {
-                                if (that.configManager.lazyFilterEnabled) {
-                                    var filterVal = "*" + val;
-                                    val = filterVal.split(' ').join('*');
+                                // following code is to UNESCAPE all special chars for ESRI and geoApi SQL to parse properly (remove the backslash)
+                                var escRegex = /\\[(!"#$&\'+,.\\\/:;<=>?@[\]^`{|}~)]/g;
+                                // remVal stores the remaining string text after the last special char (or the entire string, if there are no special chars at all)
+                                var remVal = val;
+                                var newVal = '';
+                                var escMatch = escRegex.exec(val);
+                                // lastIdx stores the last found index of the start of an escaped special char
+                                var lastIdx = 0;
+                                while (escMatch) {
+                                    // update all variables after finding an escaped special char, preserving all text except the backslash
+                                    newVal = newVal + val.substr(lastIdx, escMatch.index - lastIdx) + escMatch[0].slice(-1);
+                                    lastIdx = escMatch.index + 2;
+                                    remVal = val.substr(escMatch.index + 2);
+                                    escMatch = escRegex.exec(val);
                                 }
-                                return "UPPER(" + col + ") LIKE '" + val.replace(/\*/g, '%').toUpperCase() + "%'";
+                                newVal = newVal + remVal;
+                                // console.log(`remaining val: ${remVal} new val: ${newVal} old val: ${val}`);
+                                // add ௌ before % and/or _ to act as the escape character
+                                // can change to MOST other characters and should still work (ideally want an escape char no one will search for) - just replace all instances of ௌ
+                                newVal = newVal.replace(/%/g, 'ௌ%');
+                                newVal = newVal.replace(/_/g, 'ௌ_');
+                                if (that.configManager.lazyFilterEnabled) {
+                                    var filterVal = "*" + newVal;
+                                    newVal = filterVal.split(' ').join('*');
+                                }
+                                // if val contains a % or _, add ESCAPE 'ௌ' at the end of the query
+                                var sqlWhere = "UPPER(" + col + ") LIKE '" + newVal.replace(/\*/g, '%').toUpperCase() + "%'";
+                                return sqlWhere.includes('ௌ%') || sqlWhere.includes('ௌ_') ? sqlWhere + " ESCAPE '\u0BCC'" : sqlWhere;
                             }
                         }
                     case 'number':

--- a/lib/enhancedTable/panel-state-manager.js
+++ b/lib/enhancedTable/panel-state-manager.js
@@ -23,7 +23,12 @@ var PanelStateManager = /** @class */ (function () {
         return this.columnFilters[colDefField];
     };
     PanelStateManager.prototype.setColumnFilter = function (colDefField, filterValue) {
-        this.columnFilters[colDefField] = filterValue;
+        var newFilterValue = filterValue;
+        if (filterValue && typeof filterValue === 'string') {
+            var escRegex = /[(!"#$%&\'+,.\\\/:;<=>?@[\]^`{|}~)]/g;
+            newFilterValue = filterValue.replace(escRegex, '\\$&');
+        }
+        this.columnFilters[colDefField] = newFilterValue;
     };
     Object.defineProperty(PanelStateManager.prototype, "sortModel", {
         get: function () {


### PR DESCRIPTION
## Link to issue number(s):
fgpv-vpgf/fgpv-vpgf#3647

## Summary of the issue:
Filtering using special characters (such as `?^.|`) does not filter column data appropriately. 

## Description of how this pull request fixes the issue:
Escape all special characters before setting/applying column filters. The `%` character is handled as a special case in the where clause using: `... LIKE '%'ௌ%%' ESCAPE ''ௌ'` to meet ESRI formatting standards. This case needs handling in the geoApi SQL parser. The only special char that will not work is `*`, since it is used for properties like `lazyFilter`. 

## Testing:

-   [ ] Test specs are up-to-date & cover all changes/additions made by this PR.
-   [ ] `npm run test` passes locally.

<!-- Comment if additional testing was performed or if test specs are not suited to cover all cases. Provide links to external resources where appropriate.  -->

## Documentation

-   [ ] Documentation is up-to-date - any changes or additions have been noted
-   [ ] `changelog.md` has been updated

## Checklist

-   [x] PR has only one commit (squash otherwise)
-   [x] Commit message is descriptive

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/plugins/120)
<!-- Reviewable:end -->
