### PR TITLE
feat(enhancedTable): add schema options to disable show filters by default

### DIFF
--- a/enhancedTable/config-manager.ts
+++ b/enhancedTable/config-manager.ts
@@ -118,6 +118,13 @@ export class ConfigManager {
     }
 
     /**
+     * Returns if the column filters are displayed on the table. If undefined default to true.
+     */
+    get showFilter(): boolean {
+        return (this.tableConfig.showFilter !== undefined) ? this.tableConfig.showFilter : true;
+    }
+
+    /**
      * Returns a list of column data defined in the config, so that the table can be initialized according to them.
      */
     get filteredAttributes(): any[] {

--- a/enhancedTable/index.ts
+++ b/enhancedTable/index.ts
@@ -244,6 +244,9 @@ export default class TableBuilder {
                 }, refreshInterval * 60000);
             }
 
+            // Set menu defaults from config
+            this.tableOptions.floatingFilter = this.panelManager.panelStateManager.showFilter;
+
             this.panelManager.open(this.tableOptions, attrBundle.layer, this);
             this.tableApi = this.tableOptions.api;
         });

--- a/enhancedTable/panel-manager.ts
+++ b/enhancedTable/panel-manager.ts
@@ -459,7 +459,7 @@ export class PanelManager {
         this.mapApi.agControllerRegister('MenuCtrl', function () {
             this.appID = that.mapApi.id;
             this.maximized = that.maximized ? 'true' : 'false';
-            this.showFilter = !!that.tableOptions.floatingFilter;
+            this.showFilter = that.panelStateManager.colFilter;
             this.filterByExtent = that.panelStateManager.filterByExtent;
             this.printEnabled = that.configManager.printEnabled;
 
@@ -484,6 +484,8 @@ export class PanelManager {
 
             // Hide filters button has been clicked
             this.toggleFilters = function () {
+                that.panelStateManager.colFilter = this.showFilter;
+
                 that.tableOptions.floatingFilter = this.showFilter;
                 that.tableOptions.api.refreshHeader();
             };

--- a/enhancedTable/panel-state-manager.ts
+++ b/enhancedTable/panel-state-manager.ts
@@ -11,7 +11,8 @@ export class PanelStateManager {
     constructor(baseLayer: any, legendBlock: any) {
         this.baseLayer = baseLayer;
         this.isMaximized = baseLayer.table.maximize || false;
-        this.filterByExtent = false;
+        this.showFilter = baseLayer.table.showFilter;
+        this.filterByExtent = baseLayer.table.filterByExtent || false;
         this.columnFilters = {};
         this.open = true;
         this.storedBlock = legendBlock;
@@ -47,6 +48,14 @@ export class PanelStateManager {
         return this.isMaximized;
     }
 
+    get colFilter(): boolean {
+        return this.showFilter;
+    }
+
+    set colFilter(show: boolean) {
+        this.showFilter = show;
+    }
+
     set isOpen(isOpen: boolean) {
         this.open = isOpen;
     }
@@ -63,6 +72,7 @@ export class PanelStateManager {
 export interface PanelStateManager {
     baseLayer: any;
     isMaximized: boolean;
+    showFilter: boolean;
     filterByExtent: boolean;
     rows: any;
     columnFilters: any;

--- a/lib/enhancedTable/config-manager.js
+++ b/lib/enhancedTable/config-manager.js
@@ -135,6 +135,16 @@ var ConfigManager = /** @class */ (function () {
         enumerable: true,
         configurable: true
     });
+    Object.defineProperty(ConfigManager.prototype, "showFilter", {
+        /**
+         * Returns if the column filters are displayed on the table. If undefined default to true.
+         */
+        get: function () {
+            return (this.tableConfig.showFilter !== undefined) ? this.tableConfig.showFilter : true;
+        },
+        enumerable: true,
+        configurable: true
+    });
     Object.defineProperty(ConfigManager.prototype, "filteredAttributes", {
         /**
          * Returns a list of column data defined in the config, so that the table can be initialized according to them.

--- a/lib/enhancedTable/index.js
+++ b/lib/enhancedTable/index.js
@@ -212,6 +212,8 @@ var TableBuilder = /** @class */ (function () {
                     _this.panelManager.showToast();
                 }, refreshInterval * 60000);
             }
+            // Set menu defaults from config
+            _this.tableOptions.floatingFilter = _this.panelManager.panelStateManager.showFilter;
             _this.panelManager.open(_this.tableOptions, attrBundle.layer, _this);
             _this.tableApi = _this.tableOptions.api;
         });

--- a/lib/enhancedTable/panel-manager.js
+++ b/lib/enhancedTable/panel-manager.js
@@ -407,7 +407,7 @@ var PanelManager = /** @class */ (function () {
         this.mapApi.agControllerRegister('MenuCtrl', function () {
             this.appID = that.mapApi.id;
             this.maximized = that.maximized ? 'true' : 'false';
-            this.showFilter = !!that.tableOptions.floatingFilter;
+            this.showFilter = that.panelStateManager.colFilter;
             this.filterByExtent = that.panelStateManager.filterByExtent;
             this.printEnabled = that.configManager.printEnabled;
             // sets the table size, either split view or full height
@@ -428,6 +428,7 @@ var PanelManager = /** @class */ (function () {
             };
             // Hide filters button has been clicked
             this.toggleFilters = function () {
+                that.panelStateManager.colFilter = this.showFilter;
                 that.tableOptions.floatingFilter = this.showFilter;
                 that.tableOptions.api.refreshHeader();
             };

--- a/lib/enhancedTable/panel-state-manager.js
+++ b/lib/enhancedTable/panel-state-manager.js
@@ -13,7 +13,8 @@ var PanelStateManager = /** @class */ (function () {
     function PanelStateManager(baseLayer, legendBlock) {
         this.baseLayer = baseLayer;
         this.isMaximized = baseLayer.table.maximize || false;
-        this.filterByExtent = false;
+        this.showFilter = baseLayer.table.showFilter;
+        this.filterByExtent = baseLayer.table.filterByExtent || false;
         this.columnFilters = {};
         this.open = true;
         this.storedBlock = legendBlock;
@@ -46,6 +47,16 @@ var PanelStateManager = /** @class */ (function () {
         },
         set: function (maximized) {
             this.isMaximized = maximized;
+        },
+        enumerable: true,
+        configurable: true
+    });
+    Object.defineProperty(PanelStateManager.prototype, "colFilter", {
+        get: function () {
+            return this.showFilter;
+        },
+        set: function (show) {
+            this.showFilter = show;
         },
         enumerable: true,
         configurable: true


### PR DESCRIPTION
## Link to issue number(s):
https://github.com/fgpv-vpgf/fgpv-vpgf/issues/3665

Sister PR: on the way

## Summary of the issue:
Adds the ability to have `filter by extent` and `show filters` disabled by default.

## Description of how this pull request fixes the issue:
Implements above

## Testing:

-   [ ] Test specs are up-to-date & cover all changes/additions made by this PR.
-   [ ] `npm run test` passes locally.

<!-- Comment if additional testing was performed or if test specs are not suited to cover all cases. Provide links to external resources where appropriate.  -->

## Documentation

-   [ ] Documentation is up-to-date - any changes or additions have been noted
-   [ ] `changelog.md` has been updated

## Checklist

-   [x] PR has only one commit (squash otherwise)
-   [x] Commit message is descriptive

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/plugins/122)
<!-- Reviewable:end -->
