### PR TITLE
clear out any old doc pages

### DIFF
--- a/bin/build/travis/dist-build.sh
+++ b/bin/build/travis/dist-build.sh
@@ -8,7 +8,9 @@ else
     echo "gh-pages does not exist!"
 fi
 
+
 mkdir -p ./page_files/$TRAVIS_BRANCH
+rm -rf ./page_files/$TRAVIS_BRANCH/*
 npm run nonPublishedBuild
 
 cp -pr ./dist "./page_files/$TRAVIS_BRANCH/build"


### PR DESCRIPTION
## Link to issue number(s):

The **number** of builds that are failing haaaaa 👴 

## Summary of the issue:

Upon a second build on a branch, the command to move new docs into doc folder would fail because the docs of the previous build were still lurking there.

## Description of how this pull request fixes the issue:

Command added to clean out any old docs.
Command provided courtesy of Muffin Engineer Petrov.

## Testing:

-   [ ] Test specs are up-to-date & cover all changes/additions made by this PR.
-   [ ] `npm run test` passes locally.

<!-- Comment if additional testing was performed or if test specs are not suited to cover all cases. Provide links to external resources where appropriate.  -->

## Documentation

-   [x] Documentation is up-to-date - any changes or additions have been noted
-   [ ] `changelog.md` has been updated

## Checklist

-   [x] PR has only one commit (squash otherwise)
-   [x] Commit message is descriptive

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/plugins/131)
<!-- Reviewable:end -->
