### PR TITLE
fix(enhancedTable): fix lat/long map filtering

### DIFF
--- a/enhancedTable/custom-floating-filters.ts
+++ b/enhancedTable/custom-floating-filters.ts
@@ -304,13 +304,20 @@ export class NumberFloatingFilter {
     onMinInputBoxChanged() {
         if (this.minFilterInput.value === '') {
             this.currentValues.min = null;
+        } else if (this.minFilterInput.value === '-') {
+            this.currentValues.min = -Number.MAX_VALUE;
+        } else if (isNaN(this.minFilterInput.value)) {
+            // TODO: error message for wrong input type
+            this.minFilterInput.value = this.currentValues.min;
         } else {
             this.currentValues.min = Number(this.minFilterInput.value);
         }
 
         // save value on panel reload manager
         let key = this.params.currColumn.field + ' min';
-        this.params.panelStateManager.setColumnFilter(key, this.currentValues.min);
+        // handle filtering negative values by replacing - with the largest negative number
+        this.currentValues.min === -Number.MAX_VALUE ?
+        this.params.panelStateManager.setColumnFilter(key, '-') : this.params.panelStateManager.setColumnFilter(key, this.currentValues.min);
 
         this.onFloatingFilterChanged({ model: this.getModel() });
     }
@@ -319,13 +326,20 @@ export class NumberFloatingFilter {
     onMaxInputBoxChanged() {
         if (this.maxFilterInput.value === '') {
             this.currentValues.max = null;
+        } else if (this.maxFilterInput.value === '-') {
+            this.currentValues.max = -Number.MAX_VALUE;
+        } else if (isNaN(this.maxFilterInput.value)) {
+            // TODO: error message for wrong input type
+            this.maxFilterInput.value = this.currentValues.max;
         } else {
             this.currentValues.max = Number(this.maxFilterInput.value);
         }
 
         // save value on panel reload manager
         let key = this.params.currColumn.field + ' max';
-        this.params.panelStateManager.setColumnFilter(key, this.currentValues.max);
+        // handle filtering negative values by replacing - with the largest negative number
+        this.currentValues.max === -Number.MAX_VALUE ?
+        this.params.panelStateManager.setColumnFilter(key, '-') : this.params.panelStateManager.setColumnFilter(key, this.currentValues.max);
 
         this.onFloatingFilterChanged({ model: this.getModel() });
     }

--- a/enhancedTable/panel-manager.ts
+++ b/enhancedTable/panel-manager.ts
@@ -664,7 +664,6 @@ export class PanelManager {
                                     escMatch = escRegex.exec(val);
                                 }
                                 newVal = newVal + remVal;
-                                // console.log(`remaining val: ${remVal} new val: ${newVal} old val: ${val}`);
 
                                 // add ௌ before % and/or _ to act as the escape character
                                 // can change to MOST other characters and should still work (ideally want an escape char no one will search for) - just replace all instances of ௌ

--- a/lib/enhancedTable/custom-floating-filters.js
+++ b/lib/enhancedTable/custom-floating-filters.js
@@ -278,12 +278,21 @@ var NumberFloatingFilter = /** @class */ (function () {
         if (this.minFilterInput.value === '') {
             this.currentValues.min = null;
         }
+        else if (this.minFilterInput.value === '-') {
+            this.currentValues.min = -Number.MAX_VALUE;
+        }
+        else if (isNaN(this.minFilterInput.value)) {
+            // TODO: error message for wrong input type
+            this.minFilterInput.value = this.currentValues.min;
+        }
         else {
             this.currentValues.min = Number(this.minFilterInput.value);
         }
         // save value on panel reload manager
         var key = this.params.currColumn.field + ' min';
-        this.params.panelStateManager.setColumnFilter(key, this.currentValues.min);
+        // handle filtering negative values by replacing - with the largest negative number
+        this.currentValues.min === -Number.MAX_VALUE ?
+            this.params.panelStateManager.setColumnFilter(key, '-') : this.params.panelStateManager.setColumnFilter(key, this.currentValues.min);
         this.onFloatingFilterChanged({ model: this.getModel() });
     };
     /** Update filter maximum */
@@ -291,12 +300,21 @@ var NumberFloatingFilter = /** @class */ (function () {
         if (this.maxFilterInput.value === '') {
             this.currentValues.max = null;
         }
+        else if (this.maxFilterInput.value === '-') {
+            this.currentValues.max = -Number.MAX_VALUE;
+        }
+        else if (isNaN(this.maxFilterInput.value)) {
+            // TODO: error message for wrong input type
+            this.maxFilterInput.value = this.currentValues.max;
+        }
         else {
             this.currentValues.max = Number(this.maxFilterInput.value);
         }
         // save value on panel reload manager
         var key = this.params.currColumn.field + ' max';
-        this.params.panelStateManager.setColumnFilter(key, this.currentValues.max);
+        // handle filtering negative values by replacing - with the largest negative number
+        this.currentValues.max === -Number.MAX_VALUE ?
+            this.params.panelStateManager.setColumnFilter(key, '-') : this.params.panelStateManager.setColumnFilter(key, this.currentValues.max);
         this.onFloatingFilterChanged({ model: this.getModel() });
     };
     /** Helper function to determine filter model */

--- a/lib/enhancedTable/panel-manager.js
+++ b/lib/enhancedTable/panel-manager.js
@@ -1,7 +1,5 @@
 "use strict";
-Object.defineProperty(exports, "__esModule", {
-    value: true
-});
+Object.defineProperty(exports, "__esModule", { value: true });
 var ag_grid_community_1 = require("ag-grid-community");
 var templates_1 = require("./templates");
 var details_and_zoom_buttons_1 = require("./details-and-zoom-buttons");
@@ -79,18 +77,21 @@ var PanelManager = /** @class */ (function () {
                 if (event.keyCode === 9 && focusedCell === null) {
                     // if first tab into grid body automatically focus on first cell
                     that.tableOptions.api.setFocusedCell(0, 'rvSymbol');
-                } else if (focusedCell !== null && event.keyCode === 27) {
+                }
+                else if (focusedCell !== null && event.keyCode === 27) {
                     // on esc key, clear focused cell
                     that.tableOptions.api.clearFocusedCell();
                 }
-            } else {
+            }
+            else {
                 that.tableOptions.api.clearFocusedCell();
             }
             if ((event.keyCode !== 9 && event.keyCode !== 27) || ($('.element-focused')[0] === undefined && inList)) {
                 // if you are not tabbing or you are tabbing within a list or you're not pressing the escape key
                 // set body to be scrollable
                 $('.ag-body-viewport')[0].style.position = 'static';
-            } else {
+            }
+            else {
                 // if you are tabbing between lists, body should be absolute
                 $('.ag-body-viewport')[0].style.position = 'absolute';
             }
@@ -127,7 +128,8 @@ var PanelManager = /** @class */ (function () {
         var _this = this;
         if (this.currentTableLayer === layer) {
             this.panel.close();
-        } else {
+        }
+        else {
             // close previous table properly if open
             if (this.currentTableLayer) {
                 this.panel.close();
@@ -156,7 +158,8 @@ var PanelManager = /** @class */ (function () {
                         _this.tableOptions.overlayNoRowsTemplate = "<span class='rv-render-tooltip'>" + focusedCellText.innerHTML + "</span>";
                         _this.tableOptions.api.showNoRowsOverlay();
                         positionTooltip();
-                    } else {
+                    }
+                    else {
                         // if a text is contained within newly focused cell, hide any overlay tooltips
                         _this.tableOptions.api.hideOverlay();
                     }
@@ -243,13 +246,12 @@ var PanelManager = /** @class */ (function () {
                     setTimeout(function () {
                         tableBuilder.deleteLoaderPanel();
                     }, 400);
-                } else {
+                }
+                else {
                     tableBuilder.deleteLoaderPanel();
                 }
                 _this.tableOptions.columnDefs.forEach(function (column) {
-                    var matchingCol = _this.columnMenuCtrl.columnVisibilities.find(function (col) {
-                        return col.id === column.field;
-                    });
+                    var matchingCol = _this.columnMenuCtrl.columnVisibilities.find(function (col) { return col.id === column.field; });
                     if (matchingCol !== undefined && matchingCol.visibility === false) {
                         //temporarily show column filter of hidden columns(so that table gets filtered properly)
                         _this.columnMenuCtrl.toggleColumn(matchingCol);
@@ -283,9 +285,7 @@ var PanelManager = /** @class */ (function () {
     };
     PanelManager.prototype.onBtnExport = function () {
         var dataColumns = this.tableOptions.columnApi.getAllDisplayedVirtualColumns().slice(3);
-        this.tableOptions.api.exportDataAsCsv({
-            columnKeys: dataColumns
-        });
+        this.tableOptions.api.exportDataAsCsv({ columnKeys: dataColumns });
     };
     PanelManager.prototype.onBtnPrint = function () {
         var win = window.open('../print-table.html', '_blank');
@@ -307,13 +307,10 @@ var PanelManager = /** @class */ (function () {
     };
     PanelManager.prototype.setSize = function () {
         if (this.maximized) {
-            this.panel.element.css({
-                bottom: '0'
-            });
-        } else {
-            this.panel.element.css({
-                bottom: '50%'
-            });
+            this.panel.element.css({ bottom: '0' });
+        }
+        else {
+            this.panel.element.css({ bottom: '50%' });
         }
     };
     PanelManager.prototype.isMobile = function () {
@@ -344,12 +341,11 @@ var PanelManager = /** @class */ (function () {
         var availableWidth = panel.getWidthForSizeColsToFit();
         var usedWidth = panel.columnController.getWidthOfColsInList(columns);
         if (usedWidth < availableWidth) {
-            var symbolCol = columns.find(function (c) {
-                return c.colId === 'zoom';
-            });
+            var symbolCol = columns.find(function (c) { return c.colId === 'zoom'; });
             if (columns.length === 3) {
                 symbolCol.maxWidth = undefined;
-            } else {
+            }
+            else {
                 symbolCol.maxWidth = 40;
             }
             this.tableOptions.api.sizeColumnsToFit();
@@ -407,25 +403,23 @@ var PanelManager = /** @class */ (function () {
     PanelManager.prototype.angularHeader = function () {
         var that = this;
         this.mapApi.agControllerRegister('ToastCtrl', ['$scope', '$mdToast', '$rootElement', function ($scope, $mdToast, $rootElement) {
-            that.showToast = function () {
-                if ($rootElement.find('.table-toast').length === 0) {
-                    $mdToast.show({
-                        template: templates_1.TABLE_UPDATE_TEMPLATE,
-                        parent: that.panel.element[0],
-                        position: 'bottom rv-flex-global',
-                        hideDelay: false,
-                        controller: 'ToastCtrl'
-                    });
-                }
-            };
-            $scope.reloadTable = function () {
-                that.reload(that.currentTableLayer);
-                $mdToast.hide();
-            };
-            $scope.closeToast = function () {
-                return $mdToast.hide();
-            };
-        }]);
+                that.showToast = function () {
+                    if ($rootElement.find('.table-toast').length === 0) {
+                        $mdToast.show({
+                            template: templates_1.TABLE_UPDATE_TEMPLATE,
+                            parent: that.panel.element[0],
+                            position: 'bottom rv-flex-global',
+                            hideDelay: false,
+                            controller: 'ToastCtrl'
+                        });
+                    }
+                };
+                $scope.reloadTable = function () {
+                    that.reload(that.currentTableLayer);
+                    $mdToast.hide();
+                };
+                $scope.closeToast = function () { return $mdToast.hide(); };
+            }]);
         this.mapApi.agControllerRegister('SearchCtrl', function () {
             that.searchText = that.configManager.defaultGlobalSearch;
             this.searchText = that.searchText ? that.searchText : '';
@@ -435,7 +429,8 @@ var PanelManager = /** @class */ (function () {
                 if (this.searchText.length > 2) {
                     that.tableOptions.api.setQuickFilter(this.searchText);
                     that.panelRowsManager.quickFilterText = this.searchText;
-                } else {
+                }
+                else {
                     that.tableOptions.api.setQuickFilter('');
                     that.panelRowsManager.quickFilterText = '';
                 }
@@ -485,7 +480,8 @@ var PanelManager = /** @class */ (function () {
                 // On toggle, filter by extent or remove the extent filter
                 if (that.panelStateManager.filterByExtent) {
                     that.panelRowsManager.filterByExtent(that.mapApi.mapI.extent);
-                } else {
+                }
+                else {
                     that.panelRowsManager.fetchValidOids();
                 }
             };
@@ -526,7 +522,8 @@ var PanelManager = /** @class */ (function () {
                     });
                     // if column filters don't exist or are static, clearFilters button is disabled
                     return noFilters && !that.searchText;
-                } else {
+                }
+                else {
                     return true;
                 }
             };
@@ -576,7 +573,8 @@ var PanelManager = /** @class */ (function () {
                     case 'text':
                         if (column.isSelector) {
                             return "UPPER(" + col + ") IN (" + colFilter.filter.toUpperCase() + ")";
-                        } else {
+                        }
+                        else {
                             var val = colFilter.filter.replace(/'/g, /''/);
                             if (val !== '') {
                                 // following code is to UNESCAPE all special chars for ESRI and geoApi SQL to parse properly (remove the backslash)
@@ -595,7 +593,6 @@ var PanelManager = /** @class */ (function () {
                                     escMatch = escRegex.exec(val);
                                 }
                                 newVal = newVal + remVal;
-                                // console.log(`remaining val: ${remVal} new val: ${newVal} old val: ${val}`);
                                 // add ௌ before % and/or _ to act as the escape character
                                 // can change to MOST other characters and should still work (ideally want an escape char no one will search for) - just replace all instances of ௌ
                                 newVal = newVal.replace(/%/g, 'ௌ%');
@@ -609,32 +606,32 @@ var PanelManager = /** @class */ (function () {
                                 return sqlWhere.includes('ௌ%') || sqlWhere.includes('ௌ_') ? sqlWhere + " ESCAPE '\u0BCC'" : sqlWhere;
                             }
                         }
-                        case 'number':
-                            switch (colFilter.type) {
-                                case 'greaterThanOrEqual':
-                                    return col + " >= " + colFilter.filter;
-                                case 'lessThanOrEqual':
-                                    return col + " <= " + colFilter.filter;
-                                case 'inRange':
-                                    return col + " >= " + colFilter.filter + " AND " + col + " <= " + colFilter.filterTo;
-                                default:
-                                    break;
-                            }
-                            case 'date':
-                                var dateFrom = new Date(colFilter.dateFrom);
-                                var dateTo = new Date(colFilter.dateTo);
-                                var from = dateFrom ? dateFrom.getMonth() + 1 + "/" + dateFrom.getDate() + "/" + dateFrom.getFullYear() : undefined;
-                                var to = dateTo ? dateTo.getMonth() + 1 + "/" + dateTo.getDate() + "/" + dateTo.getFullYear() : undefined;
-                                switch (colFilter.type) {
-                                    case 'greaterThanOrEqual':
-                                        return col + " >= DATE '" + from + "'";
-                                    case 'lessThanOrEqual':
-                                        return col + " <= DATE '" + from + "'"; // ag-grid uses from for a single upper limit as well
-                                    case 'inRange':
-                                        return col + " >= DATE '" + from + "' AND " + col + " <= DATE '" + to + "'";
-                                    default:
-                                        break;
-                                }
+                    case 'number':
+                        switch (colFilter.type) {
+                            case 'greaterThanOrEqual':
+                                return col + " >= " + colFilter.filter;
+                            case 'lessThanOrEqual':
+                                return col + " <= " + colFilter.filter;
+                            case 'inRange':
+                                return col + " >= " + colFilter.filter + " AND " + col + " <= " + colFilter.filterTo;
+                            default:
+                                break;
+                        }
+                    case 'date':
+                        var dateFrom = new Date(colFilter.dateFrom);
+                        var dateTo = new Date(colFilter.dateTo);
+                        var from = dateFrom ? dateFrom.getMonth() + 1 + "/" + dateFrom.getDate() + "/" + dateFrom.getFullYear() : undefined;
+                        var to = dateTo ? dateTo.getMonth() + 1 + "/" + dateTo.getDate() + "/" + dateTo.getFullYear() : undefined;
+                        switch (colFilter.type) {
+                            case 'greaterThanOrEqual':
+                                return col + " >= DATE '" + from + "'";
+                            case 'lessThanOrEqual':
+                                return col + " <= DATE '" + from + "'"; // ag-grid uses from for a single upper limit as well
+                            case 'inRange':
+                                return col + " >= DATE '" + from + "' AND " + col + " <= DATE '" + to + "'";
+                            default:
+                                break;
+                        }
                 }
             }
             // convert global search to SQL string filter of columns excluding unfiltered columns
@@ -652,9 +649,7 @@ var PanelManager = /** @class */ (function () {
                 var sortedRows = that.tableOptions.api.rowModel.rowsToDisplay;
                 var columns = that.tableOptions.columnApi
                     .getAllDisplayedColumns()
-                    .filter(function (column) {
-                        return column.colDef.filter === 'agTextColumnFilter';
-                    });
+                    .filter(function (column) { return column.colDef.filter === 'agTextColumnFilter'; });
                 columns.splice(0, 3);
                 var filteredColumns = [];
                 columns.forEach(function (column) {
@@ -674,19 +669,11 @@ var PanelManager = /** @class */ (function () {
             that.columnMenuCtrl = this;
             this.columns = that.tableOptions.columnDefs;
             this.columnVisibilities = this.columns
-                .filter(function (element) {
-                    return element.headerName;
-                })
+                .filter(function (element) { return element.headerName; })
                 .map(function (element) {
-                    return {
-                        id: element.field,
-                        title: element.headerName,
-                        visibility: !element.hide
-                    };
-                })
-                .sort(function (firstEl, secondEl) {
-                    return firstEl['title'].localeCompare(secondEl['title']);
-                });
+                return { id: element.field, title: element.headerName, visibility: !element.hide };
+            })
+                .sort(function (firstEl, secondEl) { return firstEl['title'].localeCompare(secondEl['title']); });
             // toggle column visibility
             this.toggleColumn = function (col) {
                 var column = that.tableOptions.columnApi.getColumn(col.id);


### PR DESCRIPTION
## Link to issue number(s):
Closes fgpv-vpgf/fgpv-vpgf#3694 and fgpv-vpgf/fgpv-vpgf#3689

## Summary of the issue:
Could not correctly apply filters to map for lat/long columns because it was treated as string values. Other problems included not being able to filter number columns such as OBJECTID with negative values and using any string character following a number would delete the entire filter value. 

## Description of how this pull request fixes the issue:
GeoApi now changes CSV files to `esriFieldTypeDouble` so lat/long columns can be filtered in the same way as OBJECTID and other number columns. Added more checks for `-` input to represent searching for negative value ranges and reverted filter input back to the previous filter value that was still a number value. 

## Testing:

-   [ ] Test specs are up-to-date & cover all changes/additions made by this PR.
-   [ ] `npm run test` passes locally.

<!-- Comment if additional testing was performed or if test specs are not suited to cover all cases. Provide links to external resources where appropriate.  -->

## Documentation

-   [ ] Documentation is up-to-date - any changes or additions have been noted
-   [ ] `changelog.md` has been updated

## Checklist

-   [x] PR has only one commit (squash otherwise)
-   [x] Commit message is descriptive

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/plugins/132)
<!-- Reviewable:end -->
