### PR TITLE
fix(enhancedTable): fix md-menu contents not appearing in IE

### DIFF
--- a/enhancedTable/main.scss
+++ b/enhancedTable/main.scss
@@ -166,3 +166,6 @@ md-datepicker>div {
     -ms-user-select: text;
     user-select: text;
 }
+
+// fix for md-menu elements not showing up immediately in IE (see: https://github.com/angular/material/issues/11226)
+.md-open-menu-container > md-menu-content > * { transition: none !important; }

--- a/lib/enhancedTable/main.css
+++ b/lib/enhancedTable/main.css
@@ -3742,7 +3742,6 @@ md-datepicker > div {
   white-space: normal;
   word-wrap: break-word;
   line-height: 1.5;
-  top: 20px;
   left: -1px;
   max-width: 250px;
   overflow: hidden; }
@@ -3822,3 +3821,6 @@ md-datepicker > div {
   -moz-user-select: text;
   -ms-user-select: text;
   user-select: text; }
+
+.md-open-menu-container > md-menu-content > * {
+  transition: none !important; }


### PR DESCRIPTION
## Link to issue number(s):
https://github.com/fgpv-vpgf/fgpv-vpgf/issues/3574

## Summary of the issue:
In IE, clicking on the `Hide columns` or `More options` buttons in the table results in the dropdown elements not appearing until you hover over them.

## Description of how this pull request fixes the issue:
From what I could tell from a bit of Googling, the issue is not going to be fixed as the problem is with IE11 and there's a workaround (see https://github.com/angular/material/issues/11226). I used a slightly modified version of the workaround in the comments of that issue to solve our problem.

## Testing:

-   [ ] Test specs are up-to-date & cover all changes/additions made by this PR.
-   [ ] `npm run test` passes locally.

<!-- Comment if additional testing was performed or if test specs are not suited to cover all cases. Provide links to external resources where appropriate.  -->

## Documentation

-   [ ] Documentation is up-to-date - any changes or additions have been noted
-   [ ] `changelog.md` has been updated

## Checklist

-   [x] PR has only one commit (squash otherwise)
-   [x] Commit message is descriptive
