### PR TITLE
fix(enhancedTable): fix table not opening in IE

### DIFF
--- a/enhancedTable/index.ts
+++ b/enhancedTable/index.ts
@@ -174,7 +174,7 @@ export default class TableBuilder {
                         cellRenderer: function (cell) {
                             const translated = $(`<span>{{ 'plugins.enhancedTable.table.complexValue' | translate }}</span>`);
                             self.mapApi.$compile(translated);
-                            return cell.value || Number.isInteger(cell.value) ? (typeof cell.value === 'object' ? translated[0] : cell.value) : '';
+                            return cell.value || !isNaN(cell.value) ? (typeof cell.value === 'object' ? translated[0] : cell.value) : '';
                         },
                         suppressSorting: false,
                         suppressFilter: column.searchDisabled,

--- a/lib/enhancedTable/index.js
+++ b/lib/enhancedTable/index.js
@@ -163,7 +163,7 @@ var TableBuilder = /** @class */ (function () {
                         cellRenderer: function (cell) {
                             var translated = $("<span>{{ 'plugins.enhancedTable.table.complexValue' | translate }}</span>");
                             self.mapApi.$compile(translated);
-                            return cell.value || Number.isInteger(cell.value) ? (typeof cell.value === 'object' ? translated[0] : cell.value) : '';
+                            return cell.value || !isNaN(cell.value) ? (typeof cell.value === 'object' ? translated[0] : cell.value) : '';
                         },
                         suppressSorting: false,
                         suppressFilter: column.searchDisabled,


### PR DESCRIPTION
## Link to issue number(s):
Closes https://github.com/fgpv-vpgf/fgpv-vpgf/issues/3722

## Summary of the issue:
Datatables do not open for some layers in IE because IE does not support `Number.isInteger()`.

## Description of how this pull request fixes the issue:
Replaced with `!isNaN()` to keep the same functionality. 

## Testing:

-   [ ] Test specs are up-to-date & cover all changes/additions made by this PR.
-   [ ] `npm run test` passes locally.

<!-- Comment if additional testing was performed or if test specs are not suited to cover all cases. Provide links to external resources where appropriate.  -->

## Documentation

-   [ ] Documentation is up-to-date - any changes or additions have been noted
-   [ ] `changelog.md` has been updated

## Checklist

-   [x] PR has only one commit (squash otherwise)
-   [x] Commit message is descriptive

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/plugins/139)
<!-- Reviewable:end -->
