### PR TITLE
fix(enhancedTable): fix column filters on table reopen with Show Filters off 

### DIFF
--- a/enhancedTable/index.ts
+++ b/enhancedTable/index.ts
@@ -243,8 +243,8 @@ export default class TableBuilder {
                 }, refreshInterval * 60000);
             }
 
-            // Set menu defaults from config
-            this.tableOptions.floatingFilter = this.panelManager.panelStateManager.showFilter;
+            // Reset floatingFilter to true, will be updated onGridReady to match last value of panelStateManager.showFilter
+            this.tableOptions.floatingFilter = true;
 
             this.panelManager.open(this.tableOptions, attrBundle.layer, this);
             this.tableApi = this.tableOptions.api;

--- a/enhancedTable/panel-manager.ts
+++ b/enhancedTable/panel-manager.ts
@@ -232,7 +232,7 @@ export class PanelManager {
             this.panel.element.find('.rv-record-count').remove(); // remove old count if there
             this.panel.element.find('header').append(recordCountTemplate[0]);
 
-            //create details and zoom buttons, open the panel and display proper filter values
+            // create details and zoom buttons, open the panel and display proper filter values
             new DetailsAndZoomButtons(this);
             this.panel.body.empty();
             new Grid(this.panel.body[0], tableOptions);
@@ -279,11 +279,16 @@ export class PanelManager {
 
                 this.panelStatusManager.getFilterStatus();
 
+                // on table reopen with show filters off, reset floatingFilter and set to false to proc onFloatingFilterChanged in custom-floating-filters
+                if (!this.panelStateManager.showFilter && this.panelStateManager.showFilter !== this.tableOptions.floatingFilter) {
+                    this.tableOptions.floatingFilter = this.panelStateManager.showFilter;
+                    this.tableOptions.api.refreshHeader();
+                }
 
                 // stop loading panel from opening, if we are about to open enhancedTable
                 clearTimeout(tableBuilder.loadingTimeout);
                 if (tableBuilder.loadingPanel.isOpen) {
-                    //if loading panel was opened, make sure it stays on for at least 400 ms
+                    // if loading panel was opened, make sure it stays on for at least 400 ms
                     setTimeout(() => {
                         tableBuilder.deleteLoaderPanel();
                     }, 400);
@@ -294,9 +299,9 @@ export class PanelManager {
                 this.tableOptions.columnDefs.forEach(column => {
                     const matchingCol = this.columnMenuCtrl.columnVisibilities.find(col => col.id === column.field);
                     if (matchingCol !== undefined && matchingCol.visibility === false) {
-                        //temporarily show column filter of hidden columns(so that table gets filtered properly)
+                        // temporarily show column filter of hidden columns (so that table gets filtered properly)
                         this.columnMenuCtrl.toggleColumn(matchingCol);
-                        //then hide column(to respect config specifications)
+                        // then hide column (to respect config specifications)
                         this.columnMenuCtrl.toggleColumn(matchingCol);
                     }
                 });

--- a/lib/enhancedTable/index.js
+++ b/lib/enhancedTable/index.js
@@ -212,8 +212,8 @@ var TableBuilder = /** @class */ (function () {
                     _this.panelManager.showToast();
                 }, refreshInterval * 60000);
             }
-            // Set menu defaults from config
-            _this.tableOptions.floatingFilter = _this.panelManager.panelStateManager.showFilter;
+            // Reset floatingFilter to true, will be updated onGridReady to match last value of panelStateManager.showFilter
+            _this.tableOptions.floatingFilter = true;
             _this.panelManager.open(_this.tableOptions, attrBundle.layer, _this);
             _this.tableApi = _this.tableOptions.api;
         });

--- a/lib/enhancedTable/panel-manager.js
+++ b/lib/enhancedTable/panel-manager.js
@@ -199,7 +199,7 @@ var PanelManager = /** @class */ (function () {
             this.recordCountScope = this.mapApi.$compile(recordCountTemplate);
             this.panel.element.find('.rv-record-count').remove(); // remove old count if there
             this.panel.element.find('header').append(recordCountTemplate[0]);
-            //create details and zoom buttons, open the panel and display proper filter values
+            // create details and zoom buttons, open the panel and display proper filter values
             new details_and_zoom_buttons_1.DetailsAndZoomButtons(this);
             this.panel.body.empty();
             new ag_grid_community_1.Grid(this.panel.body[0], tableOptions);
@@ -239,10 +239,15 @@ var PanelManager = /** @class */ (function () {
                 _this.gridBody.tabIndex = 0; // make grid container tabable
                 grid_accessibility_1.initAccessibilityListeners(_this.panel.element[0], _this.gridBody, _this.tableOptions);
                 _this.panelStatusManager.getFilterStatus();
+                // on table reopen with show filters off, reset floatingFilter and set to false to proc onFloatingFilterChanged in custom-floating-filters
+                if (!_this.panelStateManager.showFilter && _this.panelStateManager.showFilter !== _this.tableOptions.floatingFilter) {
+                    _this.tableOptions.floatingFilter = _this.panelStateManager.showFilter;
+                    _this.tableOptions.api.refreshHeader();
+                }
                 // stop loading panel from opening, if we are about to open enhancedTable
                 clearTimeout(tableBuilder.loadingTimeout);
                 if (tableBuilder.loadingPanel.isOpen) {
-                    //if loading panel was opened, make sure it stays on for at least 400 ms
+                    // if loading panel was opened, make sure it stays on for at least 400 ms
                     setTimeout(function () {
                         tableBuilder.deleteLoaderPanel();
                     }, 400);
@@ -253,9 +258,9 @@ var PanelManager = /** @class */ (function () {
                 _this.tableOptions.columnDefs.forEach(function (column) {
                     var matchingCol = _this.columnMenuCtrl.columnVisibilities.find(function (col) { return col.id === column.field; });
                     if (matchingCol !== undefined && matchingCol.visibility === false) {
-                        //temporarily show column filter of hidden columns(so that table gets filtered properly)
+                        // temporarily show column filter of hidden columns (so that table gets filtered properly)
                         _this.columnMenuCtrl.toggleColumn(matchingCol);
-                        //then hide column(to respect config specifications)
+                        // then hide column (to respect config specifications)
                         _this.columnMenuCtrl.toggleColumn(matchingCol);
                     }
                 });


### PR DESCRIPTION
## Link to issue number(s):
Closes https://github.com/fgpv-vpgf/fgpv-vpgf/issues/3674

## Summary of the issue:
Closing and reopening a table after turning `Show Filters` off causes table to be unfiltered until `Show Filters` is turned back on.

## Description of how this pull request fixes the issue:
Reset the `tableOptions.floatingFilter` value and toggle it once when grid is ready after reopen to trigger `onFloatingFilterChanged` in `custom-floating-filters` which will initialize the filters normally.

## Testing:

-   [ ] Test specs are up-to-date & cover all changes/additions made by this PR.
-   [ ] `npm run test` passes locally.

<!-- Comment if additional testing was performed or if test specs are not suited to cover all cases. Provide links to external resources where appropriate.  -->

## Documentation

-   [ ] Documentation is up-to-date - any changes or additions have been noted
-   [ ] `changelog.md` has been updated

## Checklist

-   [x] PR has only one commit (squash otherwise)
-   [x] Commit message is descriptive

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/plugins/142)
<!-- Reviewable:end -->
