### PR TITLE
fix(enhancedTable): fix horizontal scroll not appearing in Chrome

### DIFF
--- a/enhancedTable/main.scss
+++ b/enhancedTable/main.scss
@@ -167,5 +167,10 @@ md-datepicker>div {
     user-select: text;
 }
 
+// preserve horizontal scroll when there are no rows to display
+.ag-body-container {
+    min-height: 2px;
+}
+
 // fix for md-menu elements not showing up immediately in IE (see: https://github.com/angular/material/issues/11226)
 .md-open-menu-container > md-menu-content > * { transition: none !important; }

--- a/lib/enhancedTable/main.css
+++ b/lib/enhancedTable/main.css
@@ -3822,5 +3822,8 @@ md-datepicker > div {
   -ms-user-select: text;
   user-select: text; }
 
+.ag-body-container {
+  min-height: 2px; }
+
 .md-open-menu-container > md-menu-content > * {
   transition: none !important; }


### PR DESCRIPTION
## Link to issue number(s):
https://github.com/fgpv-vpgf/fgpv-vpgf/issues/3737

## Summary of the issue:
When there are no rows to display in the table, the horizontal scroll bar will disappear.

## Description of how this pull request fixes the issue:
Adds a minimum height to the table body. The height was previously being set to 1px, which is removing the scroll bar for some reason. 2px works just fine 😄 

## Testing:

-   [ ] Test specs are up-to-date & cover all changes/additions made by this PR.
-   [ ] `npm run test` passes locally.

<!-- Comment if additional testing was performed or if test specs are not suited to cover all cases. Provide links to external resources where appropriate.  -->

## Documentation

-   [ ] Documentation is up-to-date - any changes or additions have been noted
-   [ ] `changelog.md` has been updated

## Checklist

-   [x] PR has only one commit (squash otherwise)
-   [x] Commit message is descriptive

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/plugins/144)
<!-- Reviewable:end -->
