### PR TITLE
fix(enhancedTable): fix filters for tables with lazyFilters enabled

### DIFF
--- a/enhancedTable/custom-floating-filters.ts
+++ b/enhancedTable/custom-floating-filters.ts
@@ -126,10 +126,18 @@ export function setUpTextFilter(colDef: any, isStatic: boolean, lazyFilterEnable
         }
     }
 
+    // default to regex filtering for text columns
     if (!lazyFilterEnabled) {
-        // Default to "regex" filtering for text columns
         colDef.filterParams.textCustomComparator = function (filter, value, filterText) {
             const re = new RegExp(`^${filterText.replace(/\*/, '.*')}`);
+            return re.test(value);
+        }
+    } else {
+        colDef.filterParams.textCustomComparator = function (filter, value, filterText) {
+            // treat * as a regular special char with lazy filter on
+            const newFilterText = filterText.replace(/\*/, '\\*');
+            // surround filter text with .* to match anything before and after
+            const re = new RegExp(`^.*${newFilterText}.*`);
             return re.test(value);
         }
     }

--- a/lib/enhancedTable/custom-floating-filters.js
+++ b/lib/enhancedTable/custom-floating-filters.js
@@ -110,10 +110,19 @@ function setUpTextFilter(colDef, isStatic, lazyFilterEnabled, searchStrictMatchE
             return disregardAccents_1(params.value);
         };
     }
+    // default to regex filtering for text columns
     if (!lazyFilterEnabled) {
-        // Default to "regex" filtering for text columns
         colDef.filterParams.textCustomComparator = function (filter, value, filterText) {
             var re = new RegExp("^" + filterText.replace(/\*/, '.*'));
+            return re.test(value);
+        };
+    }
+    else {
+        colDef.filterParams.textCustomComparator = function (filter, value, filterText) {
+            // treat * as a regular special char with lazy filter on
+            var newFilterText = filterText.replace(/\*/, '\\*');
+            // surround filter text with .* to match anything before and after
+            var re = new RegExp("^.*" + newFilterText + ".*");
             return re.test(value);
         };
     }


### PR DESCRIPTION
## Link to issue number(s):
https://github.com/fgpv-vpgf/fgpv-vpgf/issues/3736

## Summary of the issue:
Filtering with special characters did not work for layers with `lazyFilter` enabled. 

## Description of how this pull request fixes the issue:
Write a separate regex filtering `textCustomComparator` for tables with `lazyFilter` enabled.

## Testing:

-   [ ] Test specs are up-to-date & cover all changes/additions made by this PR.
-   [ ] `npm run test` passes locally.

<!-- Comment if additional testing was performed or if test specs are not suited to cover all cases. Provide links to external resources where appropriate.  -->

## Documentation

-   [ ] Documentation is up-to-date - any changes or additions have been noted
-   [ ] `changelog.md` has been updated

## Checklist

-   [x] PR has only one commit (squash otherwise)
-   [x] Commit message is descriptive

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/plugins/145)
<!-- Reviewable:end -->
