### PR TITLE
fix(enhancedTable): changed sql for global search to reflect quick search filters

### DIFF
--- a/enhancedTable/panel-manager.ts
+++ b/enhancedTable/panel-manager.ts
@@ -633,6 +633,7 @@ export class PanelManager {
                 Object.keys(filterModel).forEach(col => {
                     colStrs.push(filterToSql(col, filterModel[col]));
                 });
+                // if we want global search text length to be at least 3, then maybe we want to disable `apply filters to map` button as well since it would show all points on the map
                 if (that.searchText && that.searchText.length > 2) {
                     const globalSearchVal = globalSearchToSql() !== '' ? globalSearchToSql() : '1=2';
                     if (globalSearchVal) {
@@ -718,31 +719,63 @@ export class PanelManager {
 
             // convert global search to SQL string filter of columns excluding unfiltered columns
             function globalSearchToSql(): string {
+                // TODO: support for global search on dates
                 let val = that.searchText.replace(/'/g, "''");
-                const filterVal = `%${val
-                    .replace(/\*/g, '%')
-                    .split(' ')
-                    .join('%')
-                    .toUpperCase()}`;
-                const re = new RegExp(
-                    `.*${val
-                        .split(' ')
-                        .join('.*')
-                        .toUpperCase()}`
-                );
+                // to implement quick filters, first need to split the search text on white space
+                const searchVals = val.split(' ');
                 const sortedRows = that.tableOptions.api.rowModel.rowsToDisplay;
                 const columns = that.tableOptions.columnApi
                     .getAllDisplayedColumns()
-                    .filter(column => column.colDef.filter === 'agTextColumnFilter');
+                    .filter(column => column.colDef.filter === 'agTextColumnFilter' || column.colDef.filter === 'agNumberColumnFilter');
                 columns.splice(0, 3);
-                let filteredColumns = [];
-                columns.forEach(column => {
-                    for (let row of sortedRows) {
-                        const cellData = row.data[column.colId] === null ? null : row.data[column.colId].toString();
-                        if (cellData !== null && re.test(cellData.toUpperCase())) {
-                            filteredColumns.push(`UPPER(${column.colId}) LIKE \'${filterVal}%\'`);
-                            return;
+                let filteredColumns = <any>[];
+
+                sortedRows.forEach(row => {
+                    let rowMatch = true;
+                    let rowSql = '';
+                    // each row must contain all of the split search values
+                    for (let searchVal of searchVals) {
+                        const re = new RegExp(
+                            `.*${searchVal
+                                .split(' ')
+                                .join('.*')
+                                .toUpperCase()}`
+                        );
+                        const filterVal = `%${searchVal
+                            .replace(/\*/g, '%')
+                            .split(' ')
+                            .join('%')
+                            .toUpperCase()}`;
+                        // if any column data matches the search val in regex form, set foundVal to true and proceed to next search term
+                        let foundVal = false;
+                        for (let column of columns) {
+                            // process global search sql independently for text and number columnns
+                            if (column.colDef.filter === 'agTextColumnFilter') {
+                                const cellData = row.data[column.colId] === null ? null : row.data[column.colId].toString();
+                                if (cellData !== null && re.test(cellData.toUpperCase())) {
+                                    rowSql ? rowSql = rowSql.concat(' AND ', `(UPPER(${column.colId}) LIKE \'${filterVal}%\')`) : rowSql = rowSql.concat('(', `(UPPER(${column.colId}) LIKE \'${filterVal}%\')`);
+                                    // if we have already stored the current sql break from loop
+                                    filteredColumns.includes(rowSql + ')') ? foundVal = false : foundVal = true;
+                                    break;
+                                }
+                            } else if (column.colDef.filter === 'agNumberColumnFilter') {
+                                const cellData = row.data[column.colId] === null ? null : row.data[column.colId];
+                                if (cellData !== null && re.test(cellData)) {
+                                    rowSql ? rowSql = rowSql.concat(' AND ', `(${column.colId} = ${cellData})`) : rowSql = rowSql.concat('(', `(${column.colId} = ${cellData})`);
+                                    filteredColumns.includes(rowSql + ')') ? foundVal = false : foundVal = true;
+                                    break;
+                                }
+                            }
+                        };
+                        // otherwise if any split search value is not found, set rowMatch to false and break because it has failed to meet criteria for quick search filters
+                        if (!foundVal) {
+                            rowMatch = false;
+                            break;
                         }
+                    }
+                    // sql is added to array iff all split search values have been found somewhere in the current row data
+                    if (rowMatch) {
+                        filteredColumns.push(rowSql + ')');
                     }
                 });
                 return filteredColumns.join(' OR ');

--- a/lib/enhancedTable/panel-manager.js
+++ b/lib/enhancedTable/panel-manager.js
@@ -562,6 +562,7 @@ var PanelManager = /** @class */ (function () {
                 Object.keys(filterModel).forEach(function (col) {
                     colStrs.push(filterToSql(col, filterModel[col]));
                 });
+                // if we want global search text length to be at least 3, then maybe we want to disable `apply filters to map` button as well since it would show all points on the map
                 if (that.searchText && that.searchText.length > 2) {
                     var globalSearchVal = globalSearchToSql() !== '' ? globalSearchToSql() : '1=2';
                     if (globalSearchVal) {
@@ -641,30 +642,64 @@ var PanelManager = /** @class */ (function () {
             }
             // convert global search to SQL string filter of columns excluding unfiltered columns
             function globalSearchToSql() {
+                // TODO: support for global search on dates
                 var val = that.searchText.replace(/'/g, "''");
-                var filterVal = "%" + val
-                    .replace(/\*/g, '%')
-                    .split(' ')
-                    .join('%')
-                    .toUpperCase();
-                var re = new RegExp(".*" + val
-                    .split(' ')
-                    .join('.*')
-                    .toUpperCase());
+                // to implement quick filters, first need to split the search text on white space
+                var searchVals = val.split(' ');
                 var sortedRows = that.tableOptions.api.rowModel.rowsToDisplay;
                 var columns = that.tableOptions.columnApi
                     .getAllDisplayedColumns()
-                    .filter(function (column) { return column.colDef.filter === 'agTextColumnFilter'; });
+                    .filter(function (column) { return column.colDef.filter === 'agTextColumnFilter' || column.colDef.filter === 'agNumberColumnFilter'; });
                 columns.splice(0, 3);
                 var filteredColumns = [];
-                columns.forEach(function (column) {
-                    for (var _i = 0, sortedRows_1 = sortedRows; _i < sortedRows_1.length; _i++) {
-                        var row = sortedRows_1[_i];
-                        var cellData = row.data[column.colId] === null ? null : row.data[column.colId].toString();
-                        if (cellData !== null && re.test(cellData.toUpperCase())) {
-                            filteredColumns.push("UPPER(" + column.colId + ") LIKE '" + filterVal + "%'");
-                            return;
+                sortedRows.forEach(function (row) {
+                    var rowMatch = true;
+                    var rowSql = '';
+                    // each row must contain all of the split search values
+                    for (var _i = 0, searchVals_1 = searchVals; _i < searchVals_1.length; _i++) {
+                        var searchVal = searchVals_1[_i];
+                        var re = new RegExp(".*" + searchVal
+                            .split(' ')
+                            .join('.*')
+                            .toUpperCase());
+                        var filterVal = "%" + searchVal
+                            .replace(/\*/g, '%')
+                            .split(' ')
+                            .join('%')
+                            .toUpperCase();
+                        // if any column data matches the search val in regex form, set foundVal to true and proceed to next search term
+                        var foundVal = false;
+                        for (var _a = 0, columns_1 = columns; _a < columns_1.length; _a++) {
+                            var column = columns_1[_a];
+                            // process global search sql independently for text and number columnns
+                            if (column.colDef.filter === 'agTextColumnFilter') {
+                                var cellData = row.data[column.colId] === null ? null : row.data[column.colId].toString();
+                                if (cellData !== null && re.test(cellData.toUpperCase())) {
+                                    rowSql ? rowSql = rowSql.concat(' AND ', "(UPPER(" + column.colId + ") LIKE '" + filterVal + "%')") : rowSql = rowSql.concat('(', "(UPPER(" + column.colId + ") LIKE '" + filterVal + "%')");
+                                    // if we have already stored the current sql break from loop
+                                    filteredColumns.includes(rowSql + ')') ? foundVal = false : foundVal = true;
+                                    break;
+                                }
+                            }
+                            else if (column.colDef.filter === 'agNumberColumnFilter') {
+                                var cellData = row.data[column.colId] === null ? null : row.data[column.colId];
+                                if (cellData !== null && re.test(cellData)) {
+                                    rowSql ? rowSql = rowSql.concat(' AND ', "(" + column.colId + " = " + cellData + ")") : rowSql = rowSql.concat('(', "(" + column.colId + " = " + cellData + ")");
+                                    filteredColumns.includes(rowSql + ')') ? foundVal = false : foundVal = true;
+                                    break;
+                                }
+                            }
                         }
+                        ;
+                        // otherwise if any split search value is not found, set rowMatch to false and break because it has failed to meet criteria for quick search filters
+                        if (!foundVal) {
+                            rowMatch = false;
+                            break;
+                        }
+                    }
+                    // sql is added to array iff all split search values have been found somewhere in the current row data
+                    if (rowMatch) {
+                        filteredColumns.push(rowSql + ')');
                     }
                 });
                 return filteredColumns.join(' OR ');


### PR DESCRIPTION
## Link to issue number(s):
Closes https://github.com/fgpv-vpgf/fgpv-vpgf/issues/3762 and https://github.com/fgpv-vpgf/fgpv-vpgf/issues/3754

## Summary of the issue:
The first issue is that global search apply to map filters does not work for number columns. The second issue is that global search applies ag-grid's `setQuickFilter` method, so the results filtered in the table versus the points filtered on the map is inconsistent for specific search values. 

## Description of how this pull request fixes the issue:
For number columns, write separate sql from text columns that is similar to how column filters are applied to map. To implement quick filters, rewrote a chunk of `globalSearchToSql()` to process each row of the already filtered table rows independently and checked for different combinations containing search values which are split by white space. These combinations are turned into sql following the old logic depending on whether it is a text or number column (works for ESRI and file-based layers). 

## Testing:

-   [ ] Test specs are up-to-date & cover all changes/additions made by this PR.
-   [ ] `npm run test` passes locally.

<!-- Comment if additional testing was performed or if test specs are not suited to cover all cases. Provide links to external resources where appropriate.  -->

## Documentation

-   [ ] Documentation is up-to-date - any changes or additions have been noted
-   [ ] `changelog.md` has been updated

## Checklist

-   [x] PR has only one commit (squash otherwise)
-   [x] Commit message is descriptive

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/plugins/148)
<!-- Reviewable:end -->
