### PR TITLE
fix(enhancedTable): fix cutoff tooltip when using maximized table

### DIFF
--- a/enhancedTable/panel-manager.ts
+++ b/enhancedTable/panel-manager.ts
@@ -165,17 +165,18 @@ export class PanelManager {
 
                         const positionTooltip = () => {
                             const tooltip = $('.rv-render-tooltip')[0];
-                            const topMargin = $(focusedCell).offset().top - $(tooltip).offset().top;
-                            const topLeft = $(focusedCell).offset().left - $(tooltip).offset().left;
-                            const overlayBottom = $('.ag-overlay').position().top + $('.ag-overlay').height();
+                            const topMargin = $(focusedCell).offset().top + $(focusedCell).height() + 10;
+                            const topLeft = $(focusedCell).offset().left;
+                            const overlayBottom = $('.ag-root').offset().top + $('.ag-root').height();
 
-                            // position the tooltip so that it is associated with the focused cell
-                            tooltip.style.top = `${topMargin + 240}px`;
-                            tooltip.style.left = `${topLeft}px`;
+                            $(tooltip).offset({top: topMargin, left: topLeft});
 
-                            if (tooltip.offsetTop + $(tooltip).height() > overlayBottom - 20) {
-                                // position the tooltip so that it stays within the grid
-                                tooltip.style.bottom = '20px';
+                            let offBottom = $(tooltip).offset().top + $(tooltip).height() > overlayBottom - 20;
+                            let offTop = $(focusedCell).offset().top - $(tooltip).height() - 10 < $('.ag-header-container').offset().top
+
+                            if (offBottom && !offTop) {
+                                // if the tooltip is off the grid, have it appear above the cell unless it would also be cut off by appearing above.
+                                $(tooltip).offset({top: $(focusedCell).offset().top - $(tooltip).height() - 10});
                             }
                         }
 

--- a/lib/enhancedTable/panel-manager.js
+++ b/lib/enhancedTable/panel-manager.js
@@ -143,15 +143,15 @@ var PanelManager = /** @class */ (function () {
                     if (focusedCellText.offsetWidth > focusedCell_1.offsetWidth) {
                         var positionTooltip = function () {
                             var tooltip = $('.rv-render-tooltip')[0];
-                            var topMargin = $(focusedCell_1).offset().top - $(tooltip).offset().top;
-                            var topLeft = $(focusedCell_1).offset().left - $(tooltip).offset().left;
-                            var overlayBottom = $('.ag-overlay').position().top + $('.ag-overlay').height();
-                            // position the tooltip so that it is associated with the focused cell
-                            tooltip.style.top = topMargin + 240 + "px";
-                            tooltip.style.left = topLeft + "px";
-                            if (tooltip.offsetTop + $(tooltip).height() > overlayBottom - 20) {
-                                // position the tooltip so that it stays within the grid
-                                tooltip.style.bottom = '20px';
+                            var topMargin = $(focusedCell_1).offset().top + $(focusedCell_1).height() + 10;
+                            var topLeft = $(focusedCell_1).offset().left;
+                            var overlayBottom = $('.ag-root').offset().top + $('.ag-root').height();
+                            $(tooltip).offset({ top: topMargin, left: topLeft });
+                            var offBottom = $(tooltip).offset().top + $(tooltip).height() > overlayBottom - 20;
+                            var offTop = $(focusedCell_1).offset().top - $(tooltip).height() - 10 < $('.ag-header-container').offset().top;
+                            if (offBottom && !offTop) {
+                                // if the tooltip is off the grid, have it appear above the cell unless it would also be cut off by appearing above.
+                                $(tooltip).offset({ top: $(focusedCell_1).offset().top - $(tooltip).height() - 10 });
                             }
                         };
                         // if the cell text is not  contained within newly focused cell, create an overlay tooltip which shows full text


### PR DESCRIPTION
## Link to issue number(s):
https://github.com/fgpv-vpgf/fgpv-vpgf/issues/3770

## Summary of the issue:
When viewing the table in maximized mode, the tooltip position was incorrect.

## Description of how this pull request fixes the issue:
The tooltip is now correctly positioned.

## Testing:

-   [ ] Test specs are up-to-date & cover all changes/additions made by this PR.
-   [ ] `npm run test` passes locally.

<!-- Comment if additional testing was performed or if test specs are not suited to cover all cases. Provide links to external resources where appropriate.  -->

## Documentation

-   [ ] Documentation is up-to-date - any changes or additions have been noted
-   [ ] `changelog.md` has been updated

## Checklist

-   [x] PR has only one commit (squash otherwise)
-   [x] Commit message is descriptive

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/plugins/149)
<!-- Reviewable:end -->
