### PR TITLE
fix(enhancedTable): tooltip always shows up when cell text is cut off

### DIFF
--- a/enhancedTable/panel-manager.ts
+++ b/enhancedTable/panel-manager.ts
@@ -161,7 +161,8 @@ export class PanelManager {
                     const focusedCell = <HTMLElement>$(`[row-index=${cell.rowIndex}]`).find(`[col-id=${cell.column.colId}]`)[0];
                     const focusedCellText = <HTMLElement>focusedCell.children[0];
 
-                    if (focusedCellText.offsetWidth > focusedCell.offsetWidth) {
+                    // display the tooltip if the width of the text is larger than the cell width (excluding the padding), and it's not a button.
+                    if (focusedCellText.offsetWidth > focusedCell.offsetWidth - 48 && !focusedCellText.classList.contains('md-button')) {
 
                         const positionTooltip = () => {
                             const tooltip = $('.rv-render-tooltip')[0];

--- a/lib/enhancedTable/panel-manager.js
+++ b/lib/enhancedTable/panel-manager.js
@@ -140,7 +140,8 @@ var PanelManager = /** @class */ (function () {
                 if (cell.rowIndex !== null) {
                     var focusedCell_1 = $("[row-index=" + cell.rowIndex + "]").find("[col-id=" + cell.column.colId + "]")[0];
                     var focusedCellText = focusedCell_1.children[0];
-                    if (focusedCellText.offsetWidth > focusedCell_1.offsetWidth) {
+                    // display the tooltip if the width of the text is larger than the cell width (excluding the padding), and it's not a button.
+                    if (focusedCellText.offsetWidth > focusedCell_1.offsetWidth - 48 && !focusedCellText.classList.contains('md-button')) {
                         var positionTooltip = function () {
                             var tooltip = $('.rv-render-tooltip')[0];
                             var topMargin = $(focusedCell_1).offset().top - $(tooltip).offset().top;


### PR DESCRIPTION
## Link to issue number(s):
https://github.com/fgpv-vpgf/fgpv-vpgf/issues/3775

## Summary of the issue:
Described in the issue linked above.

## Description of how this pull request fixes the issue:
The logic that checks whether the tooltip appears or not has been tweaked to ignore the padding on the cell.

## Testing:

-   [ ] Test specs are up-to-date & cover all changes/additions made by this PR.
-   [ ] `npm run test` passes locally.

<!-- Comment if additional testing was performed or if test specs are not suited to cover all cases. Provide links to external resources where appropriate.  -->

## Documentation

-   [ ] Documentation is up-to-date - any changes or additions have been noted
-   [ ] `changelog.md` has been updated

## Checklist

-   [x] PR has only one commit (squash otherwise)
-   [x] Commit message is descriptive

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/plugins/150)
<!-- Reviewable:end -->
